### PR TITLE
Add support for creating zip files

### DIFF
--- a/SSZipArchive.h
+++ b/SSZipArchive.h
@@ -7,10 +7,25 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "minizip/zip.h"
 
-@interface SSZipArchive : NSObject
+@interface SSZipArchive : NSObject {
+@private
+    NSString *_path;
+    zipFile _zip;    
+}
 
+// Unzip
 + (BOOL)unzipFileAtPath:(NSString *)path toDestination:(NSString *)destination;
 + (BOOL)unzipFileAtPath:(NSString *)path toDestination:(NSString *)destination overwrite:(BOOL)overwrite password:(NSString *)password error:(NSError **)error;
+
+// Zip
++ (BOOL)createZipFileAtPath:(NSString *)path withFilesAtPaths:(NSArray *)filenames;
+
+- (id)initWithPath:(NSString *)path;
+- (BOOL)open;
+- (BOOL)writeFile:(NSString *)path;
+- (BOOL)writeData:(NSData *)data filename:(NSString *)filename;
+- (BOOL)close;
 
 @end

--- a/Tests/SSZipArchiveTests.m
+++ b/Tests/SSZipArchiveTests.m
@@ -11,21 +11,32 @@
 
 @interface SSZipArchiveTests ()
 - (NSString *)_cachesPath;
+- (NSString *)_createOutputPath;
 @end
 
 @implementation SSZipArchiveTests
 
+- (void)testBasicZipping {
+	NSString *outputPath = [self _createOutputPath];
+    
+    NSArray *inputPaths = [NSArray arrayWithObjects:
+                           [outputPath stringByAppendingPathComponent:@"Readme.markdown"],
+                           [outputPath stringByAppendingPathComponent:@"LICENSE"],
+                           nil];
+    NSString *archivePath = [outputPath stringByAppendingPathComponent:@"CreatedArchive.zip"];
+    [SSZipArchive createZipFileAtPath:archivePath withFilesAtPaths:inputPaths];
+ 
+	NSFileManager *fileManager = [NSFileManager defaultManager];        
+	STAssertTrue([fileManager fileExistsAtPath:archivePath], @"Archive created");    
+}
+
 - (void)testBasicUnzipping {
 	NSString *zipPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestArchive" ofType:@"zip"];
-	NSString *outputPath = [[self _cachesPath] stringByAppendingPathComponent:@"basic"];
-	
-	NSFileManager *fileManager = [NSFileManager defaultManager];
-	if (![fileManager fileExistsAtPath:outputPath]) {
-		[fileManager createDirectoryAtPath:outputPath withIntermediateDirectories:YES attributes:nil error:nil];
-	}
+	NSString *outputPath = [self _createOutputPath];
 	
 	[SSZipArchive unzipFileAtPath:zipPath toDestination:outputPath];
 	
+	NSFileManager *fileManager = [NSFileManager defaultManager];    
 	NSString *testPath = [outputPath stringByAppendingPathComponent:@"Readme.markdown"];
 	STAssertTrue([fileManager fileExistsAtPath:testPath], @"Readme unzipped");
 	
@@ -39,6 +50,19 @@
 
 
 #pragma mark - Private
+
+- (NSString *)_createOutputPath {
+	NSString *outputPath = [[self _cachesPath] stringByAppendingPathComponent:@"basic"];
+    
+	NSFileManager *fileManager = [NSFileManager defaultManager];
+	if (![fileManager fileExistsAtPath:outputPath]) {
+		[fileManager createDirectoryAtPath:outputPath withIntermediateDirectories:YES attributes:nil error:nil];
+	}
+    
+//    NSLog(@"outputPath: %@", outputPath);
+    
+    return outputPath;
+}
 
 - (NSString *)_cachesPath {
 	return [[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject]


### PR DESCRIPTION
Basic zip files can be created (or appended to) by supplying the path to a zip file and either paths to existing files or NSData objects along with filenames.
