### PR TITLE
get rid of these three little warnings 

### DIFF
--- a/SSZipArchive.m
+++ b/SSZipArchive.m
@@ -301,7 +301,7 @@
     if (!data) {
 		return NO;
     }
-    zip_fileinfo zipInfo = {0};
+    zip_fileinfo zipInfo = {{0,0,0,0,0,0},0,0,0};
     [self zipInfo:&zipInfo setDate:[NSDate date]];
 
 	zipOpenNewFileInZip(_zip, [filename UTF8String], &zipInfo, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION);


### PR DESCRIPTION
- Missing field 'tm_min' initializer
- Suggest braces around initialization of subobject
- Missing field 'dosDate' initializer
