### PR TITLE
Bump version number in podspec

### DIFF
--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'SSZipArchive'
-  s.version      = '0.2.1'
+  s.version      = '0.2.2'
   s.summary      = 'Utility class for zipping and unzipping files on iOS and Mac.'
   s.homepage     = 'https://github.com/samsoffes/ssziparchive'
   s.author       = { 'Sam Soffes' => 'sam@samsoff.es' }
-  s.source       = { :git => 'https://github.com/samsoffes/ssziparchive.git', :tag => '0.2.1' }
+  s.source       = { :git => 'https://github.com/samsoffes/ssziparchive.git', :tag => '0.2.2' }
   s.description  = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS and Mac.'
   s.source_files = 'SSZipArchive.*', 'minizip/*.{h,c}'
   s.library      = 'z'


### PR DESCRIPTION
Would you mind bumping the version number to 0.2.2 and tagging as such so that anyone using Cocoapods to pull this down can get the latest fixes?
