### PR TITLE
Added check to ensure permissions are not explicitly set if they do not exist in the zip

### DIFF
--- a/SSZipArchive.m
+++ b/SSZipArchive.m
@@ -205,10 +205,8 @@
 	                }
                     
                     // Set the original permissions on the file
-                    if (fileInfo.external_fa != 0) {
-                        // Get the permissions
-                        uLong permissions = fileInfo.external_fa >> 16;
-                        
+                    uLong permissions = fileInfo.external_fa >> 16;
+                    if (permissions != 0) {
                         // Store it into a NSNumber
                         NSNumber *permissionsValue = @(permissions);
                         


### PR DESCRIPTION
Added a simple check to make sure the permissions are not 0 before setting them.

When the zip comes from non-POSIX systems, the permissions will not exist. This means the zip is unpacked with all files/folders having no permissions at all.
