### PR TITLE
Getting rid of a Xcode 7 warning 

### DIFF
--- a/ZipArchive/Main.h
+++ b/ZipArchive/Main.h
@@ -63,6 +63,7 @@
         keepParentDirectory:(BOOL)keepParentDirectory;
 
 - (instancetype)initWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
 
 @property (NS_NONATOMIC_IOSONLY, readonly) BOOL open;
 @property (NS_NONATOMIC_IOSONLY, readonly) BOOL close;

--- a/ZipArchive/Main.m
+++ b/ZipArchive/Main.m
@@ -516,6 +516,10 @@
     return self;
 }
 
+- (instancetype)init {
+    @throw nil;
+}
+
 - (BOOL)open {
     NSAssert((NULL == _zip), @"Attempting to open an archive which has already been opened.");
     _zip = zipOpen([_path UTF8String], APPEND_STATUS_CREATE);


### PR DESCRIPTION
"Method override for the designated initializer of the superclass '-init' not found"