### PR TITLE
Close file pointer after adding to archive

### DIFF
--- a/ZipArchive/Main.m
+++ b/ZipArchive/Main.m
@@ -628,6 +628,8 @@
     
     zipCloseFileInZip(_zip);
     free(buffer);
+    
+    fclose(input);
 
     return YES;
 }


### PR DESCRIPTION
When adding files to an archive, the file pointer was being left open.
This was preventing adding large numbers of files to an archive.