### PR TITLE
Mitigate potential memory-allocation related flaws 

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -177,6 +177,11 @@
             }
             
             char *filename = (char *)malloc(fileInfo.size_filename + 1);
+            if (filename == NULL)
+            {
+                return NO;
+            }
+            
             unzGetCurrentFileInfo(zip, &fileInfo, filename, fileInfo.size_filename + 1, NULL, 0, NULL, 0);
             filename[fileInfo.size_filename] = '\0';
             
@@ -596,9 +601,13 @@
         }
     }
     
-    zipOpenNewFileInZip3(_zip, afileName, &zipInfo, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION, 0, -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, [password UTF8String], 0);
-    
     void *buffer = malloc(CHUNK);
+    if (buffer == NULL)
+    {
+        return NO;
+    }
+
+    zipOpenNewFileInZip3(_zip, afileName, &zipInfo, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION, 0, -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, [password UTF8String], 0);
     unsigned int len = 0;
     
     while (!feof(input))

--- a/SSZipArchive/minizip/zip.c
+++ b/SSZipArchive/minizip/zip.c
@@ -828,6 +828,8 @@ extern zipFile ZEXPORT zipOpen4(const void *pathname, int append, ZPOS64_T disk_
         size_central_dir_to_read = size_central_dir;
         buf_size = SIZEDATA_INDATABLOCK;
         buf_read = (void *)ALLOC(buf_size);
+        if (buf_read == NULL)
+            err = ZIP_INTERNALERROR;
 
         if (ZSEEK64(ziinit.z_filefunc, ziinit.filestream,
                     offset_central_dir + byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
@@ -1031,6 +1033,9 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char *filename, c
         zi->ci.size_centralextrafree += 11; /* Extra space reserved for AES extra info */
 #endif
     zi->ci.central_header = (char *)ALLOC((uInt)zi->ci.size_centralheader + zi->ci.size_centralextrafree + size_comment);
+    if (zi->ci.central_header == NULL)
+        return ZIP_INTERNALERROR;
+    
     zi->ci.number_disk = zi->number_disk;
 
     /* Write central directory header */


### PR DESCRIPTION
There are couple of places in the code where the result of malloc() function is not being checked to be sure it is correct (not NULL) before use.
In our project we now must send every build for the Veracode analysis. The tool scans your binary for different kinds of security flaws, including the ones related to malloc().
My changes add checks for the return values of the malloc() function where it's not safe to use it if the result is NULL.