### PR TITLE
Guard unprotected malloc calls.

### DIFF
--- a/SSZipArchive/minizip/ioapi.c
+++ b/SSZipArchive/minizip/ioapi.c
@@ -117,9 +117,13 @@ static voidpf file_build_ioposix(FILE *file, const char *filename)
     if (file == NULL)
         return NULL;
     ioposix = (FILE_IOPOSIX*)malloc(sizeof(FILE_IOPOSIX));
+    if (ioposix == NULL)
+        return NULL;
     ioposix->file = file;
     ioposix->filenameLength = (int)strlen(filename) + 1;
     ioposix->filename = (char*)malloc(ioposix->filenameLength * sizeof(char));
+    if (ioposix->filename == NULL)
+        return NULL;
     strncpy(ioposix->filename, filename, ioposix->filenameLength);
     return (voidpf)ioposix;
 }
@@ -173,6 +177,8 @@ static voidpf ZCALLBACK fopendisk64_file_func (voidpf opaque, voidpf stream, int
         return NULL;
     ioposix = (FILE_IOPOSIX*)stream;
     diskFilename = (char*)malloc(ioposix->filenameLength * sizeof(char));
+    if (diskFilename == NULL)
+        return NULL;
     strncpy(diskFilename, ioposix->filename, ioposix->filenameLength);
     for (i = ioposix->filenameLength - 1; i >= 0; i -= 1)
     {


### PR DESCRIPTION
Veracode static scan in my project discovered these vulnerabilities. I need them fixed by the project policy.