### PR TITLE
Convert Swift code in to Swift 3 and change appropriate project settings

### DIFF
--- a/SSZipArchive/SSZipArchive+Swift.swift
+++ b/SSZipArchive/SSZipArchive+Swift.swift
@@ -10,12 +10,12 @@ import Foundation
 
 extension SSZipArchive {
     
-    static func unzipFileAtPath(path: String, toDestination destination: String, overwrite: Bool, password: String?, delegate: SSZipArchiveDelegate?) throws -> Bool {
+    static func unzipFileAtPath(_ path: String, toDestination destination: String, overwrite: Bool, password: String?, delegate: SSZipArchiveDelegate?) throws -> Bool {
         
         var success = false
         var error: NSError?
         
-        success = __unzipFileAtPath(path, toDestination: destination, overwrite: overwrite, password: password, error: &error, delegate: delegate)
+        success = __unzipFile(atPath: path, toDestination: destination, overwrite: overwrite, password: password, error: &error, delegate: delegate)
         if let throwableError = error {
             throw throwableError
         }

--- a/ZipArchive.xcodeproj/project.pbxproj
+++ b/ZipArchive.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 					};
 					B423AE191C0DF76A0004A2F1 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -561,6 +562,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -582,6 +584,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.samsoffes.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Hi,

this is fix #276 for Carthage build on XCode 8 & Swift 3 conversion. I didn't see that there has already been pull request for #280, this patch should do the same with minimal changes to the xcproject file.

Both patches will allow Carthage builds.

Pavel