### PR TITLE
Replace comma with semicolon

### DIFF
--- a/SSZipArchive/minizip/unzip.c
+++ b/SSZipArchive/minizip/unzip.c
@@ -940,7 +940,7 @@ extern int ZEXPORT unzGetCurrentFileInfo(unzFile file, unz_file_info *pfile_info
         pfile_info->internal_fa = file_info64.internal_fa;
         pfile_info->external_fa = file_info64.external_fa;
 
-        pfile_info->tmu_date = file_info64.tmu_date,
+        pfile_info->tmu_date = file_info64.tmu_date;
 
         pfile_info->compressed_size = (uLong)file_info64.compressed_size;
         pfile_info->uncompressed_size = (uLong)file_info64.uncompressed_size;


### PR DESCRIPTION
I believe this comma should be a semicolon, since this looks like a full statement, and there's no reason to want the comma operator here as far as I can see.