### PR TITLE
adding read+write permissions

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -414,8 +414,8 @@ NSString *const SSZipArchiveErrorDomain = @"SSZipArchiveErrorDomain";
                                 }
                             }
 
-                            // Set the original permissions on the file
-                            uLong permissions = fileInfo.external_fa >> 16;
+                            // Set the original permissions on the file (+read/write to solve #293)
+                            uLong permissions = fileInfo.external_fa >> 16 | 0b110000000;
                             if (permissions != 0) {
                                 // Store it into a NSNumber
                                 NSNumber *permissionsValue = @(permissions);


### PR DESCRIPTION
This would grant read+write to all uncompressed files to solve #293. An alternative way to implement it would be to make it an option.