### PR TITLE
Variable 'unzippingError' is uninitialized when used

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -247,7 +247,7 @@ NSString *const SSZipArchiveErrorDomain = @"SSZipArchiveErrorDomain";
     }
     
     NSInteger currentFileNumber = 0;
-    NSError *unzippingError;
+    NSError *unzippingError = nil;
     do {
         @autoreleasepool {
             if ([password length] == 0) {


### PR DESCRIPTION
You are lucky if unzippingError is nil. Usually it is not.