### PR TITLE
Handle zero-length arguments

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -21,6 +21,7 @@ typedef NS_ENUM(NSInteger, SSZipArchiveErrorCode) {
     SSZipArchiveErrorCodeFileInfoNotLoadable    = -3,
     SSZipArchiveErrorCodeFileContentNotReadable = -4,
     SSZipArchiveErrorCodeFailedToWriteFile      = -5,
+    SSZipArchiveErrorCodeInvalidArguments       = -6,
 };
 
 @protocol SSZipArchiveDelegate;

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -184,7 +184,7 @@ NSString *const SSZipArchiveErrorDomain = @"SSZipArchiveErrorDomain";
           toDestination:(NSString *)destination
      preserveAttributes:(BOOL)preserveAttributes
               overwrite:(BOOL)overwrite
-               password:(NSString *)password
+               password:(nullable NSString *)password
                   error:(NSError **)error
                delegate:(id<SSZipArchiveDelegate>)delegate
         progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -190,6 +190,22 @@ NSString *const SSZipArchiveErrorDomain = @"SSZipArchiveErrorDomain";
         progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
       completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError * __nullable error))completionHandler
 {
+    
+    // Guard against empty strings
+    if ([path length] == 0 || [destination length] == 0)
+    {
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: @"received invalid argument(s)"};
+        NSError *err = [NSError errorWithDomain:SSZipArchiveErrorDomain code:SSZipArchiveErrorCodeInvalidArguments userInfo:userInfo];
+        if (error)
+        {
+            *error = err;
+        }
+        if (completionHandler)
+        {
+            completionHandler(nil, NO, err);
+        }
+    }
+    
     // Begin opening
     zipFile zip = unzOpen((const char*)[path fileSystemRepresentation]);
     if (zip == NULL)


### PR DESCRIPTION
Passing zero length paths into the Swift interface causes an uncaught exception.
Longer term I'd like to guard in the Swift against anything that Objective-C might throw, but this should handle the problem for now while providing a specific error for invalid input.