### PR TITLE
support for archiving symlinks

### DIFF
--- a/ObjectiveCExample/ObjectiveCExampleTests/SSZipArchiveTests.m
+++ b/ObjectiveCExample/ObjectiveCExampleTests/SSZipArchiveTests.m
@@ -475,6 +475,10 @@
     NSDictionary* attr = [[NSFileManager defaultManager] attributesOfItemAtPath:symlinkPath error:NULL];
     NSString* fileType = attr[NSFileType];
     XCTAssertTrue([fileType isEqualToString:NSFileTypeSymbolicLink]);
+    
+    // check that symlink points correctly
+    NSString* realFilePath2 = [[NSFileManager defaultManager] destinationOfSymbolicLinkAtPath: symlinkPath error:NULL];
+    XCTAssertEqualObjects(realFilePath, realFilePath2);
 }
 
 #pragma mark - Private

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -813,8 +813,7 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
             zipInfo.external_fa = (zipInfo.external_fa & ~(BSD_SFMT << 16)) | (BSD_IFLNK << 16);
             
             int error = _zipOpenEntry(_zip, fileName, &zipInfo, Z_NO_COMPRESSION, password, 0);
-            const void *buffer = fileName.fileSystemRepresentation;
-            zipWriteInFileInZip(_zip, buffer, (uint32_t)strlen(buffer));
+            zipWriteInFileInZip(_zip, linktarget, sb.st_size);
             zipCloseFileInZip(_zip);
             ok = error == ZIP_OK;
         }

--- a/SSZipArchive/minizip/zip.c
+++ b/SSZipArchive/minizip/zip.c
@@ -66,7 +66,7 @@
 #  define BUFREADCOMMENT            (0x400)
 #endif
 #ifndef VERSIONMADEBY
-#  define VERSIONMADEBY             (0x0) /* platform dependent */
+#  define VERSIONMADEBY             (0x03<<8) /* platform dependent, this means Unix */
 #endif
 
 #ifndef Z_BUFSIZE


### PR DESCRIPTION
I needed the ability to make archives containing symlinks and I have something working that could maybe be useful.

It definitely needs someone to give it a critical look, as I have only been a casual user of SSZipArchive.

The PR does 3 things:

1. Changes the VERSIONMADEBY macro to 3 which means Unix as opposed to MS-DOS. This is required for symlink flags to be respected and both iOS and macOS seem much closer to Unix than MS-DOS, but there could very well be side-effects to this change.

2. Adjusted the logic that enumerates a directory to look for files, directories and now symlinks in `createZipFileAtPath:...`

3. Made a new method to write symlinks:
`-writeSymlinkAtPath:withFilename:targetName:withPassword:`