### PR TITLE
Support for splitting archive

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -105,11 +105,12 @@ typedef NS_ENUM(NSInteger, SSZipArchiveErrorCode) {
            compressionLevel:(int)compressionLevel
                    password:(nullable NSString *)password
                         AES:(BOOL)aes
+                   diskSize:(int)diskSize
             progressHandler:(void(^ _Nullable)(NSUInteger entryNumber, NSUInteger total))progressHandler;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
-- (BOOL)open;
+- (BOOL)openWithSplitSize:(int)disk_size;
 
 /// write empty folder
 - (BOOL)writeFolderAtPath:(NSString *)path withFolderName:(NSString *)folderName withPassword:(nullable NSString *)password;


### PR DESCRIPTION
As `minizip` is supporting splitting zip archive, I've added a way to create archive with user-defined disk size. A disk size of 0 means we're using old `open` function. I've also added a size check to avoid creating parts of less than 1 KB (useful ?).