### PR TITLE
Add measurement of zipping performance

### DIFF
--- a/ObjectiveCExample/ObjectiveCExampleTests/SSZipArchiveTests.m
+++ b/ObjectiveCExample/ObjectiveCExampleTests/SSZipArchiveTests.m
@@ -88,6 +88,28 @@
     }
 }
 
+- (void)testZippingPerformance {
+    [self measureBlock:^{
+        
+        // Input file can be changed to test zipping performance on different file types.
+        // 0.4ma is used as an example
+        NSString *inputPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"0.m4a" ofType:nil];
+        
+        NSString *outputPath = [self _cachesPath:@"Zipped"];
+        NSString *archivePath = [outputPath stringByAppendingString:@"outputZip_performance"];
+        
+        BOOL success = [SSZipArchive createZipFileAtPath:archivePath withFilesAtPaths:@[inputPath]];
+        XCTAssertTrue(success);
+        
+        long long inputFileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:inputPath
+                                                                                    error:nil][NSFileSize] longLongValue];
+        long long outputFileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:archivePath
+                                                                                     error:nil][NSFileSize] longLongValue];
+        NSLog(@"Input file of size %lld compressed to %lld sized zip file", inputFileSize, outputFileSize);
+        
+    }];
+}
+
 - (void)testUnzipping {
     NSString *zipPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestArchive" ofType:@"zip"];
     NSString *outputPath = [self _cachesPath:@"Regular"];


### PR DESCRIPTION
Added test case to measure zipping performance. 

## **Performance Testing** 

Performed performance test on a sample **text file containing ASCII characters**. Test results will vary for different file types and devices. Below are the test results for illustration.

**Test device** - iPhone 4s (A5 chipset, 512MB RAM, Dual-core 1GHz Cortex-A9)

| Original file size | Time | Compressed file size |
| --- | --- | --- |
| 1 MB | 0.201s | 150 KB |
| 2.5 MB | 0.476s | 360 KB |
| 5 MB | 0.948s | 744 KB | 
| 7.5 MB | 1.402s | 1.08 MB |
| 10 MB | 1.919s | 1.48 MB |
| 25 MB | 4.641s | 3.7 MB |