### PR TITLE
optimization, perform a shallow search instead of a deep enumeration

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -726,18 +726,17 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
             NSString *fullFilePath = [directoryPath stringByAppendingPathComponent:fileName];
             [fileManager fileExistsAtPath:fullFilePath isDirectory:&isDir];
             
-            if (keepParentDirectory)
-            {
+            if (keepParentDirectory) {
                 fileName = [directoryPath.lastPathComponent stringByAppendingPathComponent:fileName];
             }
             
             if (!isDir) {
+                // file
                 success &= [zipArchive writeFileAtPath:fullFilePath withFileName:fileName compressionLevel:compressionLevel password:password AES:aes];
-            }
-            else
-            {
-                if ([[NSFileManager defaultManager] subpathsOfDirectoryAtPath:fullFilePath error:nil].count == 0)
-                {
+            } else {
+                // directory
+                if ([fileManager contentsOfDirectoryAtPath:fullFilePath error:nil].count == 0) {
+                    // empty directory
                     success &= [zipArchive writeFolderAtPath:fullFilePath withFolderName:fileName withPassword:password];
                 }
             }


### PR DESCRIPTION
Apple's API description:

`- (NSArray<NSString *> *)subpathsOfDirectoryAtPath:(NSString *)path error:(NSError * _Nullable *)error;`
> Performs a deep enumeration of the specified directory and returns the paths of all of the contained subdirectories.
> Because this method recurses the directory’s contents, you might not want to use it in performance-critical code. 

`- (NSArray<NSString *> *)contentsOfDirectoryAtPath:(NSString *)path error:(NSError * _Nullable *)error;`
> Performs a shallow search of the specified directory and returns the paths of any contained items.