### PR TITLE
File path sanitation compatible with Unicode

### DIFF
--- a/ObjectiveCExample/ObjectiveCExampleTests/SSZipArchiveTests.m
+++ b/ObjectiveCExample/ObjectiveCExampleTests/SSZipArchiveTests.m
@@ -553,9 +553,13 @@
       // path traversal without slash
       @"..": @"",
       // permissions override
+      @"./": @"",
       @".": @"",
-      // unicode in folder name and file name
-      @"example/../à: 𝚨 󌞑/你好.txt": @"à: 𝚨 󌞑/你好.txt",
+      // unicode and spaces in folder name and file name
+      @"example/../à: 𝚨 󌞑/你 好.txt": @"à: 𝚨 󌞑/你 好.txt",
+      // unicode that looks like '.' or '/' in ascii decomposition
+      @"a/ğ/../b": @"a/b",
+      @"a/⸮/b/.ⸯ/c/⼮./d": @"a/⸮/b/.ⸯ/c/⼮./d",
       // scheme in name
       @"file:a/../../../usr/bin": @"usr/bin",
       };

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -1113,6 +1113,8 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo)
 
 @implementation NSString (SSZipArchive)
 
+// One alternative would be to use the algorithm found at mz_path_resolve from https://github.com/nmoinvaz/minizip/blob/dev/mz_os.c,
+// but making sure to work with unichar values and not ascii values to avoid breaking Unicode characters containing 2E ('.') or 2F ('/') in their decomposition
 - (NSString *)_sanitizedPath
 {
     // Change Windows paths to Unix paths: https://en.wikipedia.org/wiki/Path_(computing)


### PR DESCRIPTION
This is a follow up to my review on #456 and the issues I found on 28th August 2018.

* improve security by dealing with "." and "..", preventing permissions override
* fix Unicode support in folder names
