### PR TITLE
Fix Carthage not see SSZipCommon.h

### DIFF
--- a/ZipArchive.xcodeproj/project.pbxproj
+++ b/ZipArchive.xcodeproj/project.pbxproj
@@ -141,7 +141,7 @@
 		37952C881F63BBD500DD6677 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE481C0DF7950004A2F1 /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		37952C891F63BBDA00DD6677 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = B423AE491C0DF7950004A2F1 /* SSZipArchive.m */; };
 		37952C8B1F63BBE400DD6677 /* ZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE4A1C0DF7950004A2F1 /* ZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		93CE5D5E227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; };
+		93CE5D5E227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93CE5D5F227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; };
 		93CE5D60227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; };
 		93CE5D61227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; };
@@ -419,6 +419,7 @@
 			files = (
 				3775F3C92276B14400A1840B /* mz_strm_zlib.h in Headers */,
 				3775F3A12276B14400A1840B /* mz_strm.h in Headers */,
+				93CE5D5E227FE5C50003464F /* SSZipCommon.h in Headers */,
 				3775F3A92276B14400A1840B /* mz_strm_buf.h in Headers */,
 				3775F3712276B14400A1840B /* mz_os.h in Headers */,
 				3775F3652276B14400A1840B /* mz.h in Headers */,
@@ -431,7 +432,6 @@
 				3775F3892276B14400A1840B /* mz_strm_pkcrypt.h in Headers */,
 				3775F35D2276B14400A1840B /* mz_strm_os.h in Headers */,
 				3775F3952276B14400A1840B /* mz_zip_rw.h in Headers */,
-				93CE5D5E227FE5C50003464F /* SSZipCommon.h in Headers */,
 				3775F3912276B14400A1840B /* mz_compat.h in Headers */,
 				3775F37D2276B14400A1840B /* mz_strm_wzaes.h in Headers */,
 			);

--- a/ZipArchive.xcodeproj/project.pbxproj
+++ b/ZipArchive.xcodeproj/project.pbxproj
@@ -141,6 +141,10 @@
 		37952C881F63BBD500DD6677 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE481C0DF7950004A2F1 /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		37952C891F63BBDA00DD6677 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = B423AE491C0DF7950004A2F1 /* SSZipArchive.m */; };
 		37952C8B1F63BBE400DD6677 /* ZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE4A1C0DF7950004A2F1 /* ZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93CE5D5E227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; };
+		93CE5D5F227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; };
+		93CE5D60227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; };
+		93CE5D61227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; };
 		AFF75A2D1C3727F000F450AC /* ZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE4A1C0DF7950004A2F1 /* ZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AFF75A2E1C37280200F450AC /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE481C0DF7950004A2F1 /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AFF75A2F1C37280200F450AC /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = B423AE491C0DF7950004A2F1 /* SSZipArchive.m */; };
@@ -193,6 +197,7 @@
 		378439CB227AC031000BC165 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS5.2.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
 		37952C261F63B50D00DD6677 /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		37952C5E1F63BB7100DD6677 /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		93CE5D5D227FE5C50003464F /* SSZipCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSZipCommon.h; sourceTree = "<group>"; };
 		AFF75A241C37279600F450AC /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B423AE1A1C0DF76A0004A2F1 /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B423AE3D1C0DF7950004A2F1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -291,6 +296,7 @@
 				B423AE3E1C0DF7950004A2F1 /* minizip */,
 				B423AE481C0DF7950004A2F1 /* SSZipArchive.h */,
 				B423AE491C0DF7950004A2F1 /* SSZipArchive.m */,
+				93CE5D5D227FE5C50003464F /* SSZipCommon.h */,
 				B423AE4A1C0DF7950004A2F1 /* ZipArchive.h */,
 			);
 			path = SSZipArchive;
@@ -353,6 +359,7 @@
 				3775F35F2276B14400A1840B /* mz_strm_os.h in Headers */,
 				3775F3972276B14400A1840B /* mz_zip_rw.h in Headers */,
 				3775F3932276B14400A1840B /* mz_compat.h in Headers */,
+				93CE5D60227FE5C50003464F /* SSZipCommon.h in Headers */,
 				3775F37F2276B14400A1840B /* mz_strm_wzaes.h in Headers */,
 				37952C341F63B71400DD6677 /* ZipArchive.h in Headers */,
 			);
@@ -376,6 +383,7 @@
 				37952C8B1F63BBE400DD6677 /* ZipArchive.h in Headers */,
 				3775F3602276B14400A1840B /* mz_strm_os.h in Headers */,
 				3775F3982276B14400A1840B /* mz_zip_rw.h in Headers */,
+				93CE5D61227FE5C50003464F /* SSZipCommon.h in Headers */,
 				3775F3942276B14400A1840B /* mz_compat.h in Headers */,
 				3775F3802276B14400A1840B /* mz_strm_wzaes.h in Headers */,
 			);
@@ -399,6 +407,7 @@
 				AFF75A2E1C37280200F450AC /* SSZipArchive.h in Headers */,
 				3775F35E2276B14400A1840B /* mz_strm_os.h in Headers */,
 				3775F3962276B14400A1840B /* mz_zip_rw.h in Headers */,
+				93CE5D5F227FE5C50003464F /* SSZipCommon.h in Headers */,
 				3775F3922276B14400A1840B /* mz_compat.h in Headers */,
 				3775F37E2276B14400A1840B /* mz_strm_wzaes.h in Headers */,
 			);
@@ -422,6 +431,7 @@
 				3775F3892276B14400A1840B /* mz_strm_pkcrypt.h in Headers */,
 				3775F35D2276B14400A1840B /* mz_strm_os.h in Headers */,
 				3775F3952276B14400A1840B /* mz_zip_rw.h in Headers */,
+				93CE5D5E227FE5C50003464F /* SSZipCommon.h in Headers */,
 				3775F3912276B14400A1840B /* mz_compat.h in Headers */,
 				3775F37D2276B14400A1840B /* mz_strm_wzaes.h in Headers */,
 			);


### PR DESCRIPTION
When trying Carthage v2.2.1, there will have include error that missing `SSZipCommon.h`

I checked that inside Carthage built framework header folder there doesn't have SSZipCommon.h, so I put it back and it fixed the build issue