### PR TITLE
Add support to Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.build/
+.vscode/
+
+
 # Xcode
 #
 xcuserdata/

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "ZipArchive",
     platforms: [
-      .macOS(.v10_10)
+      .macOS(.v10_10),
+      .iOS(.v8)
     ],
     products: [
         .executable(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ZipArchive",
+    platforms: [
+      .macOS(.v10_10)
+    ],
+    products: [
+        .executable(
+            name: "ziparc",
+            targets: ["ziparc"]),
+        .library(
+            name: "ZipArchive",
+            targets: ["ZipArchive"]),
+    ],
+    targets: [
+        .target(
+            name: "ziparc",
+            dependencies: ["ZipArchive"],
+            path: "ziparc"),
+        .target(
+            name: "ZipArchive",
+            path: "SSZipArchive")
+    ]
+)
+

--- a/SPMCLI.resolved
+++ b/SPMCLI.resolved
@@ -1,10 +1,126 @@
-mac:
+ios:
   build:
     -Xcc:
-    - -DHAVE_ARC4RANDOM_BUF
     - -DHAVE_INTTYPES_H
     - -DHAVE_PKCRYPT
     - -DHAVE_STDINT_H
     - -DHAVE_WZAES
     - -DHAVE_ZLIB
     - -DMZ_ZIP_NO_SIGNING
+    - -Wnon-modular-include-in-framework-module
+    - -Werror=non-modular-include-in-framework-module
+    - -fapplication-extension
+    - -Wno-trigraphs
+    - -fpascal-strings
+    - -O0
+    - -fno-common
+    - -Wno-missing-field-initializers
+    - -Wno-missing-prototypes
+    - -Werror=return-type
+    - -Wunreachable-code-aggressive
+    - -Werror=deprecated-objc-isa-usage
+    - -Werror=objc-root-class
+    - -Wno-missing-braces
+    - -Wparentheses
+    - -Wswitch
+    - -Wunused-function
+    - -Wno-unused-label
+    - -Wno-unused-parameter
+    - -Wunused-variable
+    - -Wunused-value
+    - -Wempty-body
+    - -Wuninitialized
+    - -Wconditional-uninitialized
+    - -Wno-unknown-pragmas
+    - -Wno-shadow
+    - -Wno-four-char-constants
+    - -Wno-conversion
+    - -Wconstant-conversion
+    - -Wint-conversion
+    - -Wbool-conversion
+    - -Wenum-conversion
+    - -Wno-float-conversion
+    - -Wnon-literal-null-conversion
+    - -Wobjc-literal-conversion
+    - -Wshorten-64-to-32
+    - -Wpointer-sign
+    - -Wno-newline-eof
+    - -fstrict-aliasing
+    - -Wdeprecated-declarations
+    - -g
+    - -Wno-sign-conversion
+    - -Winfinite-recursion
+    - -Wcomma
+    - -Wblock-capture-autoreleasing
+    - -Wstrict-prototypes
+    - -Wno-semicolon-before-method-body
+    - -arc=armv7
+    - -I/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include
+    - -isysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+    - -miphoneos-version-min=8.0
+    -Xlinker:
+    - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libz.tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libiconv.tbd
+    -Xswiftc:
+    - -target=armv7-apple-ios8.0
+    - -miphoneos-version-min=8.0
+    - -sdk=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+mac:
+  build:
+    -Xcc:
+    - -DHAVE_INTTYPES_H
+    - -DHAVE_PKCRYPT
+    - -DHAVE_STDINT_H
+    - -DHAVE_WZAES
+    - -DHAVE_ZLIB
+    - -DMZ_ZIP_NO_SIGNING
+    - -Wnon-modular-include-in-framework-module
+    - -Werror=non-modular-include-in-framework-module
+    - -fapplication-extension
+    - -Wno-trigraphs
+    - -fpascal-strings
+    - -O0
+    - -fno-common
+    - -Wno-missing-field-initializers
+    - -Wno-missing-prototypes
+    - -Werror=return-type
+    - -Wunreachable-code-aggressive
+    - -Werror=deprecated-objc-isa-usage
+    - -Werror=objc-root-class
+    - -Wno-missing-braces
+    - -Wparentheses
+    - -Wswitch
+    - -Wunused-function
+    - -Wno-unused-label
+    - -Wno-unused-parameter
+    - -Wunused-variable
+    - -Wunused-value
+    - -Wempty-body
+    - -Wuninitialized
+    - -Wconditional-uninitialized
+    - -Wno-unknown-pragmas
+    - -Wno-shadow
+    - -Wno-four-char-constants
+    - -Wno-conversion
+    - -Wconstant-conversion
+    - -Wint-conversion
+    - -Wbool-conversion
+    - -Wenum-conversion
+    - -Wno-float-conversion
+    - -Wnon-literal-null-conversion
+    - -Wobjc-literal-conversion
+    - -Wshorten-64-to-32
+    - -Wpointer-sign
+    - -Wno-newline-eof
+    - -fstrict-aliasing
+    - -Wdeprecated-declarations
+    - -g
+    - -Wno-sign-conversion
+    - -Winfinite-recursion
+    - -Wcomma
+    - -Wblock-capture-autoreleasing
+    - -Wstrict-prototypes
+    - -Wno-semicolon-before-method-body
+    -Xlinker:
+    - /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libz.tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libiconv.tbd

--- a/SPMCLI.resolved
+++ b/SPMCLI.resolved
@@ -1,0 +1,10 @@
+mac:
+  build:
+    -Xcc:
+    - -DHAVE_ARC4RANDOM_BUF
+    - -DHAVE_INTTYPES_H
+    - -DHAVE_PKCRYPT
+    - -DHAVE_STDINT_H
+    - -DHAVE_WZAES
+    - -DHAVE_ZLIB
+    - -DMZ_ZIP_NO_SIGNING

--- a/SPMCLI.resolved
+++ b/SPMCLI.resolved
@@ -1,4 +1,4 @@
-ios:
+mac:
   build:
     -Xcc:
     - -DHAVE_INTTYPES_H
@@ -54,19 +54,10 @@ ios:
     - -Wblock-capture-autoreleasing
     - -Wstrict-prototypes
     - -Wno-semicolon-before-method-body
-    - -arc=armv7
-    - -I/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include
-    - -isysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
-    - -miphoneos-version-min=8.0
     -Xlinker:
-    - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libz.tbd
-    - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libiconv.tbd
-    -Xswiftc:
-    - -target=armv7-apple-ios8.0
-    - -miphoneos-version-min=8.0
-    - -sdk=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
-mac:
-  build:
+    - /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libz.tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libiconv.tbd
+  test:
     -Xcc:
     - -DHAVE_INTTYPES_H
     - -DHAVE_PKCRYPT

--- a/SPMCLI.yaml
+++ b/SPMCLI.yaml
@@ -1,0 +1,10 @@
+mac:
+  build:
+    -Xcc:
+      - -DHAVE_ARC4RANDOM_BUF
+      - -DHAVE_INTTYPES_H
+      - -DHAVE_PKCRYPT
+      - -DHAVE_STDINT_H
+      - -DHAVE_WZAES
+      - -DHAVE_ZLIB
+      - -DMZ_ZIP_NO_SIGNING

--- a/SPMCLI.yaml
+++ b/SPMCLI.yaml
@@ -70,11 +70,13 @@ Clang:
     -Wno-semicolon-before-method-body:
 
 mac:
-  build:
+  build: &build
     -Xcc: 
       <<: *c_compiler_flag
       <<: *clang_flags
     -Xlinker: *macos_tbd
+  test:
+    <<: *build
 # ios:
 #   build:
 #     -Xcc: 

--- a/SPMCLI.yaml
+++ b/SPMCLI.yaml
@@ -1,10 +1,90 @@
+TBD_FILES:
+  macos: &macos_tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libz.tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libiconv.tbd
+  ios: &ios_tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libz.tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libiconv.tbd
+  watchos: &watchos_tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/usr/lib/libz.tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/usr/lib/libiconv.tbd
+  tvos: &tvos_tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/lib/libz.tbd
+    - /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/lib/libiconv.tbd
+Clang:
+  c_compiler_flags: &c_compiler_flag
+    -DHAVE_INTTYPES_H:
+    -DHAVE_PKCRYPT:
+    -DHAVE_STDINT_H:
+    -DHAVE_WZAES:
+    -DHAVE_ZLIB:
+    -DMZ_ZIP_NO_SIGNING:
+  clang_flags: &clang_flags
+    # -fmodules-validate-once-per-build-session:
+    -Wnon-modular-include-in-framework-module:
+    -Werror=non-modular-include-in-framework-module:
+    -fapplication-extension:
+    -Wno-trigraphs:
+    -fpascal-strings:
+    -O0:
+    -fno-common:
+    -Wno-missing-field-initializers:
+    -Wno-missing-prototypes:
+    -Werror=return-type:
+    -Wunreachable-code-aggressive:
+    -Werror=deprecated-objc-isa-usage:
+    -Werror=objc-root-class:
+    -Wno-missing-braces:
+    -Wparentheses:
+    -Wswitch:
+    -Wunused-function:
+    -Wno-unused-label:
+    -Wno-unused-parameter:
+    -Wunused-variable:
+    -Wunused-value:
+    -Wempty-body:
+    -Wuninitialized:
+    -Wconditional-uninitialized:
+    -Wno-unknown-pragmas:
+    -Wno-shadow:
+    -Wno-four-char-constants:
+    -Wno-conversion:
+    -Wconstant-conversion:
+    -Wint-conversion:
+    -Wbool-conversion:
+    -Wenum-conversion:
+    -Wno-float-conversion:
+    -Wnon-literal-null-conversion:
+    -Wobjc-literal-conversion:
+    -Wshorten-64-to-32:
+    -Wpointer-sign:
+    -Wno-newline-eof:
+    -fstrict-aliasing:
+    -Wdeprecated-declarations:
+    -g:
+    -Wno-sign-conversion:
+    -Winfinite-recursion:
+    -Wcomma:
+    -Wblock-capture-autoreleasing:
+    -Wstrict-prototypes:
+    -Wno-semicolon-before-method-body:
+
 mac:
   build:
-    -Xcc:
-      - -DHAVE_ARC4RANDOM_BUF
-      - -DHAVE_INTTYPES_H
-      - -DHAVE_PKCRYPT
-      - -DHAVE_STDINT_H
-      - -DHAVE_WZAES
-      - -DHAVE_ZLIB
-      - -DMZ_ZIP_NO_SIGNING
+    -Xcc: 
+      <<: *c_compiler_flag
+      <<: *clang_flags
+    -Xlinker: *macos_tbd
+# ios:
+#   build:
+#     -Xcc: 
+#       <<: *c_compiler_flag
+#       <<: *clang_flags
+#       -arc=armv7:
+#       -isysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk:
+#       -miphoneos-version-min=8.0:
+#     -Xlinker: *ios_tbd
+#     -Xswiftc:
+#       -target=armv7-apple-ios8.0:
+#       -miphoneos-version-min=8.0:
+#       -sdk=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk:

--- a/SPMZipArchive.xcodeproj/ZipArchive_Info.plist
+++ b/SPMZipArchive.xcodeproj/ZipArchive_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/SPMZipArchive.xcodeproj/project.pbxproj
+++ b/SPMZipArchive.xcodeproj/project.pbxproj
@@ -1,0 +1,572 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		EFBFC53922C49D0E009E5463 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFBFC53822C49D0E009E5463 /* Security.framework */; };
+		EFBFC53B22C49D39009E5463 /* libz.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = EFBFC53A22C49D39009E5463 /* libz.1.dylib */; };
+		EFBFC53D22C49D66009E5463 /* libiconv.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = EFBFC53C22C49D65009E5463 /* libiconv.2.dylib */; };
+		OBJ_51 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* SSZipArchive.m */; };
+		OBJ_52 /* mz_compat.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* mz_compat.c */; };
+		OBJ_53 /* mz_crypt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* mz_crypt.c */; };
+		OBJ_54 /* mz_crypt_apple.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* mz_crypt_apple.c */; };
+		OBJ_55 /* mz_os.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* mz_os.c */; };
+		OBJ_56 /* mz_os_posix.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* mz_os_posix.c */; };
+		OBJ_57 /* mz_strm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* mz_strm.c */; };
+		OBJ_58 /* mz_strm_buf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* mz_strm_buf.c */; };
+		OBJ_59 /* mz_strm_mem.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* mz_strm_mem.c */; };
+		OBJ_60 /* mz_strm_os_posix.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* mz_strm_os_posix.c */; };
+		OBJ_61 /* mz_strm_pkcrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* mz_strm_pkcrypt.c */; };
+		OBJ_62 /* mz_strm_split.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* mz_strm_split.c */; };
+		OBJ_63 /* mz_strm_wzaes.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* mz_strm_wzaes.c */; };
+		OBJ_64 /* mz_strm_zlib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* mz_strm_zlib.c */; };
+		OBJ_65 /* mz_zip.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* mz_zip.c */; };
+		OBJ_66 /* mz_zip_rw.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* mz_zip_rw.c */; };
+		OBJ_73 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_79 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* main.swift */; };
+		OBJ_81 /* ZipArchive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "ZipArchive::ZipArchive::Product" /* ZipArchive.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		EFBFC53622C49C9F009E5463 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "ZipArchive::ZipArchive";
+			remoteInfo = ZipArchive;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		EFBFC53822C49D0E009E5463 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		EFBFC53A22C49D39009E5463 /* libz.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.dylib; path = ../../../../usr/lib/libz.1.dylib; sourceTree = "<group>"; };
+		EFBFC53C22C49D65009E5463 /* libiconv.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.2.dylib; path = ../../../../usr/lib/libiconv.2.dylib; sourceTree = "<group>"; };
+		OBJ_10 /* SSZipArchive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SSZipArchive.h; sourceTree = "<group>"; };
+		OBJ_11 /* SSZipCommon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SSZipCommon.h; sourceTree = "<group>"; };
+		OBJ_12 /* ZipArchive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZipArchive.h; sourceTree = "<group>"; };
+		OBJ_13 /* SSZipArchive.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SSZipArchive.m; sourceTree = "<group>"; };
+		OBJ_15 /* mz_compat.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_compat.c; sourceTree = "<group>"; };
+		OBJ_16 /* mz_crypt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_crypt.c; sourceTree = "<group>"; };
+		OBJ_17 /* mz_crypt_apple.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_crypt_apple.c; sourceTree = "<group>"; };
+		OBJ_18 /* mz_os.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_os.c; sourceTree = "<group>"; };
+		OBJ_19 /* mz_os_posix.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_os_posix.c; sourceTree = "<group>"; };
+		OBJ_20 /* mz_strm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_strm.c; sourceTree = "<group>"; };
+		OBJ_21 /* mz_strm_buf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_strm_buf.c; sourceTree = "<group>"; };
+		OBJ_22 /* mz_strm_mem.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_strm_mem.c; sourceTree = "<group>"; };
+		OBJ_23 /* mz_strm_os_posix.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_strm_os_posix.c; sourceTree = "<group>"; };
+		OBJ_24 /* mz_strm_pkcrypt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_strm_pkcrypt.c; sourceTree = "<group>"; };
+		OBJ_25 /* mz_strm_split.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_strm_split.c; sourceTree = "<group>"; };
+		OBJ_26 /* mz_strm_wzaes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_strm_wzaes.c; sourceTree = "<group>"; };
+		OBJ_27 /* mz_strm_zlib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_strm_zlib.c; sourceTree = "<group>"; };
+		OBJ_28 /* mz_zip.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_zip.c; sourceTree = "<group>"; };
+		OBJ_29 /* mz_zip_rw.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mz_zip_rw.c; sourceTree = "<group>"; };
+		OBJ_31 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = /Users/pondokios/Desktop/ZipArchive/SSZipArchive/include/module.modulemap; sourceTree = "<group>"; };
+		OBJ_33 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		OBJ_38 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
+		OBJ_39 /* SSZipArchive */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SSZipArchive; sourceTree = SOURCE_ROOT; };
+		OBJ_40 /* ziparc */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ziparc; sourceTree = SOURCE_ROOT; };
+		OBJ_41 /* icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon.png; sourceTree = "<group>"; };
+		OBJ_42 /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		OBJ_43 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		OBJ_44 /* Release-Instructions.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Release-Instructions.md"; sourceTree = "<group>"; };
+		OBJ_45 /* SSZipArchive.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = SSZipArchive.podspec; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		"ZipArchive::ZipArchive::Product" /* ZipArchive.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"ZipArchive::ziparc::Product" /* ziparc */ = {isa = PBXFileReference; lastKnownFileType = text; path = ziparc; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_67 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				EFBFC53D22C49D66009E5463 /* libiconv.2.dylib in Frameworks */,
+				EFBFC53B22C49D39009E5463 /* libz.1.dylib in Frameworks */,
+				EFBFC53922C49D0E009E5463 /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_80 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_81 /* ZipArchive.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		EFBFC53722C49D0D009E5463 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EFBFC53C22C49D65009E5463 /* libiconv.2.dylib */,
+				EFBFC53A22C49D39009E5463 /* libz.1.dylib */,
+				EFBFC53822C49D0E009E5463 /* Security.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		OBJ_14 /* minizip */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_15 /* mz_compat.c */,
+				OBJ_16 /* mz_crypt.c */,
+				OBJ_17 /* mz_crypt_apple.c */,
+				OBJ_18 /* mz_os.c */,
+				OBJ_19 /* mz_os_posix.c */,
+				OBJ_20 /* mz_strm.c */,
+				OBJ_21 /* mz_strm_buf.c */,
+				OBJ_22 /* mz_strm_mem.c */,
+				OBJ_23 /* mz_strm_os_posix.c */,
+				OBJ_24 /* mz_strm_pkcrypt.c */,
+				OBJ_25 /* mz_strm_split.c */,
+				OBJ_26 /* mz_strm_wzaes.c */,
+				OBJ_27 /* mz_strm_zlib.c */,
+				OBJ_28 /* mz_zip.c */,
+				OBJ_29 /* mz_zip_rw.c */,
+			);
+			path = minizip;
+			sourceTree = "<group>";
+		};
+		OBJ_30 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_31 /* module.modulemap */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		OBJ_32 /* ziparc */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_33 /* main.swift */,
+			);
+			path = ziparc;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_34 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_35 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"ZipArchive::ziparc::Product" /* ziparc */,
+				"ZipArchive::ZipArchive::Product" /* ZipArchive.framework */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_34 /* Tests */,
+				OBJ_35 /* Products */,
+				OBJ_38 /* Example */,
+				OBJ_39 /* SSZipArchive */,
+				OBJ_40 /* ziparc */,
+				OBJ_41 /* icon.png */,
+				OBJ_42 /* LICENSE.txt */,
+				OBJ_43 /* README.md */,
+				OBJ_44 /* Release-Instructions.md */,
+				OBJ_45 /* SSZipArchive.podspec */,
+				EFBFC53722C49D0D009E5463 /* Frameworks */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* ZipArchive */,
+				OBJ_32 /* ziparc */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* ZipArchive */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Info.plist */,
+				OBJ_10 /* SSZipArchive.h */,
+				OBJ_11 /* SSZipCommon.h */,
+				OBJ_12 /* ZipArchive.h */,
+				OBJ_13 /* SSZipArchive.m */,
+				OBJ_14 /* minizip */,
+				OBJ_30 /* include */,
+			);
+			name = ZipArchive;
+			path = SSZipArchive;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"ZipArchive::SwiftPMPackageDescription" /* ZipArchivePackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_69 /* Build configuration list for PBXNativeTarget "ZipArchivePackageDescription" */;
+			buildPhases = (
+				OBJ_72 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ZipArchivePackageDescription;
+			productName = ZipArchivePackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"ZipArchive::ZipArchive" /* ZipArchive */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_47 /* Build configuration list for PBXNativeTarget "ZipArchive" */;
+			buildPhases = (
+				OBJ_50 /* Sources */,
+				OBJ_67 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ZipArchive;
+			productName = ZipArchive;
+			productReference = "ZipArchive::ZipArchive::Product" /* ZipArchive.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"ZipArchive::ziparc" /* ziparc */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_75 /* Build configuration list for PBXNativeTarget "ziparc" */;
+			buildPhases = (
+				OBJ_78 /* Sources */,
+				OBJ_80 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_82 /* PBXTargetDependency */,
+			);
+			name = ziparc;
+			productName = ziparc;
+			productReference = "ZipArchive::ziparc::Product" /* ziparc */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftMigration = 9999;
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "SPMZipArchive" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_35 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"ZipArchive::ZipArchive" /* ZipArchive */,
+				"ZipArchive::SwiftPMPackageDescription" /* ZipArchivePackageDescription */,
+				"ZipArchive::ziparc" /* ziparc */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_50 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_51 /* SSZipArchive.m in Sources */,
+				OBJ_52 /* mz_compat.c in Sources */,
+				OBJ_53 /* mz_crypt.c in Sources */,
+				OBJ_54 /* mz_crypt_apple.c in Sources */,
+				OBJ_55 /* mz_os.c in Sources */,
+				OBJ_56 /* mz_os_posix.c in Sources */,
+				OBJ_57 /* mz_strm.c in Sources */,
+				OBJ_58 /* mz_strm_buf.c in Sources */,
+				OBJ_59 /* mz_strm_mem.c in Sources */,
+				OBJ_60 /* mz_strm_os_posix.c in Sources */,
+				OBJ_61 /* mz_strm_pkcrypt.c in Sources */,
+				OBJ_62 /* mz_strm_split.c in Sources */,
+				OBJ_63 /* mz_strm_wzaes.c in Sources */,
+				OBJ_64 /* mz_strm_zlib.c in Sources */,
+				OBJ_65 /* mz_zip.c in Sources */,
+				OBJ_66 /* mz_zip_rw.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_72 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_73 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_78 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_79 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_82 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "ZipArchive::ZipArchive" /* ZipArchive */;
+			targetProxy = EFBFC53622C49C9F009E5463 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+					"DEBUG=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_48 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/SSZipArchive/include",
+				);
+				INFOPLIST_FILE = SPMZipArchive.xcodeproj/ZipArchive_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = ZipArchive;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = ZipArchive;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_49 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/SSZipArchive/include",
+				);
+				INFOPLIST_FILE = SPMZipArchive.xcodeproj/ZipArchive_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = ZipArchive;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = ZipArchive;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_70 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_71 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_76 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/SSZipArchive/include",
+				);
+				INFOPLIST_FILE = SPMZipArchive.xcodeproj/ziparc_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SSZipArchive/include/module.modulemap";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = ziparc;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_77 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/SSZipArchive/include",
+				);
+				INFOPLIST_FILE = SPMZipArchive.xcodeproj/ziparc_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/SSZipArchive/include/module.modulemap";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = ziparc;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_2 /* Build configuration list for PBXProject "SPMZipArchive" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_47 /* Build configuration list for PBXNativeTarget "ZipArchive" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_48 /* Debug */,
+				OBJ_49 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_69 /* Build configuration list for PBXNativeTarget "ZipArchivePackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_70 /* Debug */,
+				OBJ_71 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_75 /* Build configuration list for PBXNativeTarget "ziparc" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_76 /* Debug */,
+				OBJ_77 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
+}

--- a/SPMZipArchive.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SPMZipArchive.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SPMZipArchive.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SPMZipArchive.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SPMZipArchive.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/SPMZipArchive.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+    <false/>
+</dict>
+</plist>

--- a/SPMZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-Package.xcscheme
+++ b/SPMZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-Package.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ZipArchive::ZipArchive"
+               BuildableName = "ZipArchive.framework"
+               BlueprintName = "ZipArchive"
+               ReferencedContainer = "container:SPMZipArchive.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ZipArchive::ziparc"
+               BuildableName = "ziparc"
+               BlueprintName = "ziparc"
+               ReferencedContainer = "container:SPMZipArchive.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ZipArchive::ZipArchive"
+            BuildableName = "ZipArchive.framework"
+            BlueprintName = "ZipArchive"
+            ReferencedContainer = "container:SPMZipArchive.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SPMZipArchive.xcodeproj/xcshareddata/xcschemes/ziparc.xcscheme
+++ b/SPMZipArchive.xcodeproj/xcshareddata/xcschemes/ziparc.xcscheme
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ZipArchive::ziparc"
+               BuildableName = "ziparc"
+               BlueprintName = "ziparc"
+               ReferencedContainer = "container:SPMZipArchive.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ZipArchive::ziparc"
+            BuildableName = "ziparc"
+            BlueprintName = "ziparc"
+            ReferencedContainer = "container:SPMZipArchive.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SSZipArchive/include/module.modulemap
+++ b/SSZipArchive/include/module.modulemap
@@ -1,0 +1,10 @@
+module ZipArchive {
+    header "../ZipArchive.h"
+    requires objc
+
+    // Link against libz.dylib and libiconv.dylib
+    link "z"
+    link "iconv"
+
+    export *
+}

--- a/SSZipArchive/include/module.modulemap
+++ b/SSZipArchive/include/module.modulemap
@@ -1,10 +1,6 @@
 module ZipArchive {
     header "../ZipArchive.h"
-    requires objc
-
-    // Link against libz.dylib and libiconv.dylib
-    link "z"
-    link "iconv"
+    requires objc_arc
 
     export *
 }

--- a/ziparc/main.swift
+++ b/ziparc/main.swift
@@ -1,0 +1,1 @@
+import ZipArchive


### PR DESCRIPTION
This PR need to be reviewed. For now, `swift build` command will succesfully compiles the project without separately pass -Xlinker flags.
Currently Package.swift declares support for macOS only.