### PR TITLE
Added -payloadSizeForArchiveAtPath:

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -32,6 +32,9 @@ typedef NS_ENUM(NSInteger, SSZipArchiveErrorCode) {
 + (BOOL)isFilePasswordProtectedAtPath:(NSString *)path;
 + (BOOL)isPasswordValidForArchiveAtPath:(NSString *)path password:(NSString *)pw error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
+// Total payload size
++ (NSNumber *)payloadSizeForArchiveAtPath:(NSString *)path error:(NSError **)error;
+
 // Unzip
 + (BOOL)unzipFileAtPath:(NSString *)path toDestination:(NSString *)destination;
 + (BOOL)unzipFileAtPath:(NSString *)path toDestination:(NSString *)destination delegate:(nullable id<SSZipArchiveDelegate>)delegate;


### PR DESCRIPTION
This method computes the total payload size which can be useful
if you are pre-flighting data or setting up a progress bar.