### PR TITLE
Improved error message

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -115,7 +115,7 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
                     if (error) {
                         *error = [NSError errorWithDomain:SSZipArchiveErrorDomain
                                                      code:SSZipArchiveErrorCodeFailedOpenFileInZip
-                                                 userInfo:@{NSLocalizedDescriptionKey: @"failed to open first file in zip file"}];
+                                                 userInfo:@{NSLocalizedDescriptionKey: @"failed to open file in zip archive"}];
                     }
                 }
                 passwordValid = NO;
@@ -184,7 +184,7 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
                 if (error) {
                     *error = [NSError errorWithDomain:SSZipArchiveErrorDomain
                                                  code:SSZipArchiveErrorCodeFailedOpenFileInZip
-                                             userInfo:@{NSLocalizedDescriptionKey: @"failed to open first file in zip file"}];
+                                             userInfo:@{NSLocalizedDescriptionKey: @"failed to open file in zip archive"}];
                 }
                 break;
             }


### PR DESCRIPTION
The message is appropriate whether we fail on the first, second or nth
file in the archive.

Something that came up in our internal code review :-)