### PR TITLE
fix badAccess

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -366,7 +366,7 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
     }
     
     NSInteger currentFileNumber = -1;
-    NSError *unzippingError;
+    NSError *unzippingError = nil;
     do {
         currentFileNumber++;
         if (ret == MZ_END_OF_LIST) {


### PR DESCRIPTION
Calling unzipFileAtPath:toDestination:overwrite:password:error: with error,
Variable 'unzippingError' may be not nil when ' *error = unzippingError ' here. 
it may lead to badAccess after the method finishing because OC will send retain to variable 'error'