### PR TITLE
Fix garbled characters when decompressing by third-party tools.

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -1134,7 +1134,8 @@ int _zipOpenEntry(zipFile entry, NSString *name, const zip_fileinfo *zipfi, int 
 {
     // https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
     uint16_t made_on_darwin = 19 << 8;
-    return zipOpenNewFileInZip5(entry, name.fileSystemRepresentation, zipfi, NULL, 0, NULL, 0, NULL, Z_DEFLATED, level, 0, -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, password.UTF8String, aes, made_on_darwin, 0, 0);
+    uint16_t flag_base = 1 << 11;
+    return zipOpenNewFileInZip5(entry, name.fileSystemRepresentation, zipfi, NULL, 0, NULL, 0, NULL, Z_DEFLATED, level, 0, -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, password.UTF8String, aes, made_on_darwin, flag_base, 0);
 }
 
 #pragma mark - Private tools for file info

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -1134,6 +1134,7 @@ int _zipOpenEntry(zipFile entry, NSString *name, const zip_fileinfo *zipfi, int 
 {
     // https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
     uint16_t made_on_darwin = 19 << 8;
+    //MZ_ZIP_FLAG_UTF8
     uint16_t flag_base = 1 << 11;
     return zipOpenNewFileInZip5(entry, name.fileSystemRepresentation, zipfi, NULL, 0, NULL, 0, NULL, Z_DEFLATED, level, 0, -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, password.UTF8String, aes, made_on_darwin, flag_base, 0);
 }


### PR DESCRIPTION
Fix the problem that ZipArchive compressed special characters decompressed by7zip or WinRAR, display garbled characters. Because unicode bit added by PKZIP higher version is not set in the zip file header.