### PR TITLE
#492.appending to zip

### DIFF
--- a/Example/ObjectiveCExampleTests/SSZipArchiveTests.m
+++ b/Example/ObjectiveCExampleTests/SSZipArchiveTests.m
@@ -178,6 +178,33 @@ int twentyMB = 20 * 1024 * 1024;
     XCTAssertTrue([fileManager fileExistsAtPath:testPath], @"LICENSE unzipped");
 }
 
+-(void)testAppendingToZip {
+    // zip files and create "CreatedArchive.zip"
+    [self testZipping];
+    
+    NSString *outputPath = [self _cachesPath:@"Zipped"];
+    NSString *archivePath = [outputPath stringByAppendingPathComponent:@"CreatedArchive.zip"];
+    long long initialFileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:archivePath error:NULL][NSFileSize] longLongValue];
+    
+    SSZipArchive* zip = [[SSZipArchive alloc] initWithPath:archivePath];
+    
+    BOOL didOpenForAppending = [zip openForAppending];
+    XCTAssertTrue(didOpenForAppending, @"Opened for appending");
+    
+    NSData* testData = [@"test contents" dataUsingEncoding:NSUTF8StringEncoding];
+    BOOL didAppendFile = [zip writeData:testData filename:@"testData.txt" withPassword:NULL];
+    XCTAssertTrue(didAppendFile, @"Did add file");
+    
+    BOOL didClose = [zip close];
+    XCTAssertTrue(didClose, @"Can close zip");
+    
+    // TODO: Make sure the files are actually zipped. They are, but the test should be better.
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:archivePath], @"Archive created");
+    
+    long long fileSizeAfterAppend = [[[NSFileManager defaultManager] attributesOfItemAtPath:archivePath error:NULL][NSFileSize] longLongValue];
+    XCTAssertGreaterThan(fileSizeAfterAppend, initialFileSize);    
+}
+
 - (void)testUnzippingProgress {
     NSString *zipPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestArchive" ofType:@"zip"];
     NSString *outputPath = [self _cachesPath:@"Progress"];

--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -119,6 +119,7 @@ typedef NS_ENUM(NSInteger, SSZipArchiveErrorCode) {
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
 - (BOOL)open;
+- (BOOL)openForAppending;
 
 /// write empty folder
 - (BOOL)writeFolderAtPath:(NSString *)path withFolderName:(NSString *)folderName withPassword:(nullable NSString *)password;

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -868,6 +868,13 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
     return (NULL != _zip);
 }
 
+- (BOOL)openForAppending
+{
+    NSAssert((_zip == NULL), @"Attempting to open an archive which is already open");
+    _zip = zipOpen(_path.fileSystemRepresentation, APPEND_STATUS_CREATE);
+    return (NULL != _zip);
+}
+
 - (BOOL)writeFolderAtPath:(NSString *)path withFolderName:(NSString *)folderName withPassword:(nullable NSString *)password
 {
     NSAssert((_zip != NULL), @"Attempting to write to an archive which was never opened");

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -871,7 +871,7 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
 - (BOOL)openForAppending
 {
     NSAssert((_zip == NULL), @"Attempting to open an archive which is already open");
-    _zip = zipOpen(_path.fileSystemRepresentation, APPEND_STATUS_CREATE);
+    _zip = zipOpen(_path.fileSystemRepresentation, APPEND_STATUS_ADDINZIP);
     return (NULL != _zip);
 }
 


### PR DESCRIPTION
This should fix issue #492 . Implementing the suggestion by @Coeur to expose the usage of APPEND_STATUS_ADDINZIP instead of APPEND_STATUS_CREATE for support appending to existing zip files. 