### PR TITLE
2.3.0 - version bump, header updates, readme update

### DIFF
--- a/Example/ObjectiveCExample/ViewController.m
+++ b/Example/ObjectiveCExample/ViewController.m
@@ -7,11 +7,9 @@
 //
 
 #import "ViewController.h"
-#if COCOAPODS
-#import <SSZipArchive/SSZipArchive.h>
-#else
-#import <ZipArchive/SSZipArchive.h>
-#endif
+
+#import <ZipArchive.h>
+
 
 @interface ViewController ()
 

--- a/Example/ObjectiveCExample/ViewController.m
+++ b/Example/ObjectiveCExample/ViewController.m
@@ -8,7 +8,11 @@
 
 #import "ViewController.h"
 
+#if COCOAPODS
+#import <SSZipArchive.h>
+#else
 #import <ZipArchive.h>
+#endif
 
 
 @interface ViewController ()

--- a/Example/ObjectiveCExampleTests/CancelDelegate.h
+++ b/Example/ObjectiveCExampleTests/CancelDelegate.h
@@ -6,11 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if COCOAPODS
-#import <SSZipArchive/SSZipArchive.h>
-#else
-#import <ZipArchive/SSZipArchive.h>
-#endif
+#import <ZipArchive.h>
 
 @interface CancelDelegate : NSObject <SSZipArchiveDelegate>
 @property (nonatomic, assign) int numFilesUnzipped;

--- a/Example/ObjectiveCExampleTests/CancelDelegate.h
+++ b/Example/ObjectiveCExampleTests/CancelDelegate.h
@@ -6,7 +6,13 @@
 //
 
 #import <Foundation/Foundation.h>
+
+
+#if COCOAPODS
+#import <SSZipArchive.h>
+#else
 #import <ZipArchive.h>
+#endif
 
 @interface CancelDelegate : NSObject <SSZipArchiveDelegate>
 @property (nonatomic, assign) int numFilesUnzipped;

--- a/Example/ObjectiveCExampleTests/CollectingDelegate.h
+++ b/Example/ObjectiveCExampleTests/CollectingDelegate.h
@@ -1,5 +1,11 @@
 #import <Foundation/Foundation.h>
+ 
+#if COCOAPODS
+#import <SSZipArchive.h>
+#else
 #import <ZipArchive.h>
+#endif
+
 
 /**
  * Test delegate by collecting its calls

--- a/Example/ObjectiveCExampleTests/CollectingDelegate.h
+++ b/Example/ObjectiveCExampleTests/CollectingDelegate.h
@@ -1,9 +1,5 @@
 #import <Foundation/Foundation.h>
-#if COCOAPODS
-#import <SSZipArchive/SSZipArchive.h>
-#else
-#import <ZipArchive/SSZipArchive.h>
-#endif
+#import <ZipArchive.h>
 
 /**
  * Test delegate by collecting its calls

--- a/Example/ObjectiveCExampleTests/ProgressDelegate.h
+++ b/Example/ObjectiveCExampleTests/ProgressDelegate.h
@@ -7,7 +7,11 @@
 
 #import <Foundation/Foundation.h>
 
+#if COCOAPODS
+#import <SSZipArchive.h>
+#else
 #import <ZipArchive.h>
+#endif
 
 
 @interface ProgressDelegate : NSObject <SSZipArchiveDelegate>

--- a/Example/ObjectiveCExampleTests/ProgressDelegate.h
+++ b/Example/ObjectiveCExampleTests/ProgressDelegate.h
@@ -6,11 +6,9 @@
 //
 
 #import <Foundation/Foundation.h>
-#if COCOAPODS
-#import <SSZipArchive/SSZipArchive.h>
-#else
-#import <ZipArchive/SSZipArchive.h>
-#endif
+
+#import <ZipArchive.h>
+
 
 @interface ProgressDelegate : NSObject <SSZipArchiveDelegate>
 {

--- a/Example/ObjectiveCExampleTests/SSZipArchiveTests.m
+++ b/Example/ObjectiveCExampleTests/SSZipArchiveTests.m
@@ -7,7 +7,11 @@
 //
 
 
+#if COCOAPODS
+#import <SSZipArchive.h>
+#else
 #import <ZipArchive.h>
+#endif
 
 #import <XCTest/XCTest.h>
 #import <CommonCrypto/CommonDigest.h>

--- a/Example/ObjectiveCExampleTests/SSZipArchiveTests.m
+++ b/Example/ObjectiveCExampleTests/SSZipArchiveTests.m
@@ -6,11 +6,9 @@
 //  Copyright (c) 2011-2014 Sam Soffes. All rights reserved.
 //
 
-#if COCOAPODS
-#import <SSZipArchive/SSZipArchive.h>
-#else
-#import <ZipArchive/SSZipArchive.h>
-#endif
+
+#import <ZipArchive.h>
+
 #import <XCTest/XCTest.h>
 #import <CommonCrypto/CommonDigest.h>
 

--- a/Example/SwiftExample/ViewController.swift
+++ b/Example/SwiftExample/ViewController.swift
@@ -8,7 +8,11 @@
 
 import UIKit
 
-import ZipArchive
+#if UseCarthage
+    import ZipArchive
+#else
+    import SSZipArchive
+#endif
 
 class ViewController: UIViewController {
 

--- a/Example/SwiftExample/ViewController.swift
+++ b/Example/SwiftExample/ViewController.swift
@@ -8,11 +8,7 @@
 
 import UIKit
 
-#if UseCarthage
-    import ZipArchive
-#else
-    import SSZipArchive
-#endif
+import ZipArchive
 
 class ViewController: UIViewController {
 

--- a/Example/SwiftExample_macOS/ViewController.swift
+++ b/Example/SwiftExample_macOS/ViewController.swift
@@ -7,11 +7,7 @@
 
 import Cocoa
 
-#if UseCarthage
 import ZipArchive
-#else
-import SSZipArchive
-#endif
 
 class ViewController: NSViewController {
 

--- a/Example/SwiftExample_macOS/ViewController.swift
+++ b/Example/SwiftExample_macOS/ViewController.swift
@@ -7,7 +7,11 @@
 
 import Cocoa
 
-import ZipArchive
+#if UseCarthage
+    import ZipArchive
+#else
+    import SSZipArchive
+#endif
 
 class ViewController: NSViewController {
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ You should define your minimum deployment target explicitly, like:
 
 Recommended CocoaPods version should be at least CocoaPods 1.7.5.
 
+### SPM
+Add a Swift Package reference to https://github.com/ZipArchive/ZipArchive.git (SSZipArchive 2.2.4 and higher or master)
+
 ### Carthage
 In your Cartfile:  
 `github "ZipArchive/ZipArchive"`
@@ -48,6 +51,10 @@ SSZipArchive requires ARC.
 ### Objective-C
 
 ```objective-c
+
+//Import 
+#import <ZipArchive.h>  //#import <SSZipArchive.h> still works for previous code
+
 // Create
 [SSZipArchive createZipFileAtPath:zipPath withContentsOfDirectory:sampleDataPath];
 
@@ -58,6 +65,9 @@ SSZipArchive requires ARC.
 ### Swift
 
 ```swift
+//Import
+import ZipArchive //import SSZipArchive still works for previous code
+
 // Create
 SSZipArchive.createZipFileAtPath(zipPath, withContentsOfDirectory: sampleDataPath)
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ SSZipArchive requires ARC.
 
 ```objective-c
 
-//Import 
-#import <ZipArchive.h>  //#import <SSZipArchive.h> still works for previous code
+//Import "#import <ZipArchive.h>" for SPM/Carthage, and "#import <SSZipArchive.h>" for CocoaPods.
 
 // Create
 [SSZipArchive createZipFileAtPath:zipPath withContentsOfDirectory:sampleDataPath];
@@ -65,8 +64,7 @@ SSZipArchive requires ARC.
 ### Swift
 
 ```swift
-//Import
-import ZipArchive //import SSZipArchive still works for previous code
+//Import "import ZipArchive" for SPM/Carthage, and "import SSZipArchive" for CocoaPods.
 
 // Create
 SSZipArchive.createZipFileAtPath(zipPath, withContentsOfDirectory: sampleDataPath)

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SSZipArchive'
-  s.version      = '2.2.4'
+  s.version      = '2.3.0'
   s.summary      = 'Utility class for zipping and unzipping files on iOS, tvOS, watchOS, and macOS.'
   s.description  = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS, tvOS, watchOS, and macOS. It supports AES and PKWARE encryption.'
   s.homepage     = 'https://github.com/ZipArchive/ZipArchive'

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SSZipArchive'
-  s.version      = '2.2.3'
+  s.version      = '2.2.4'
   s.summary      = 'Utility class for zipping and unzipping files on iOS, tvOS, watchOS, and macOS.'
   s.description  = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS, tvOS, watchOS, and macOS. It supports AES and PKWARE encryption.'
   s.homepage     = 'https://github.com/ZipArchive/ZipArchive'


### PR DESCRIPTION
Bump verison to 2.3.0, move headers in example projects to use ZipArchive.h headers and update readme to include SPM