### PR TITLE
New parameter for SSZipArchive: useZip64

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -83,6 +83,14 @@ typedef NS_ENUM(NSInteger, SSZipArchiveErrorCode) {
         progressHandler:(void (^_Nullable)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
       completionHandler:(void (^_Nullable)(NSString *path, BOOL succeeded, NSError * _Nullable error))completionHandler;
 
+/// Locates the "entity" with `name` in the zip file at `path` and unzips it, returning it as data.
+/// Returns nil if there isn't an entity with that `name` or if any errors are encountered.
+/// The entity must be a file – directories and symlinks are ignored. Password-encrypted entities
+/// are not supported.
++ (NSData *)unzipEntityName:(NSString *)name
+               fromFilePath:(NSString *)path
+                      error:(out NSError *__autoreleasing *)outError;
+
 // Zip
 // default compression level is Z_DEFAULT_COMPRESSION (from "zlib.h")
 // keepParentDirectory: if YES, then unzipping will give `directoryName/fileName`. If NO, then unzipping will just give `fileName`. Default is NO.

--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -123,8 +123,38 @@ typedef NS_ENUM(NSInteger, SSZipArchiveErrorCode) {
             progressHandler:(void(^ _Nullable)(NSUInteger entryNumber, NSUInteger total))progressHandler
                keepSymlinks:(BOOL)keeplinks;
 
+/// Create a zip file from the contents of a directory with the following arguments:
+///   *path* the path of the zip archive
+///   *withContentsOfDirectory* the path to the directory that should be archived
+///   *keepParentDirectory* if YES, then unzipping results in `directoryName/fileName`; otherwise, results in `fileName`
+///   *compressionLevel* controls how much compression is used, e.g. Z_DEFAULT_COMPRESSION (from "zlib.h")
+///   *password* is optional
+///   *aes* encryption should not be used if compatibility with native macOS unzip and Archive Utility is required
+///   *keepSymlinks* should symlinks be retained
+///   *useZip64* should the archive use the zip64 format (for extremely large zip files) or the older zip format
+///   *progressHandler* called repeatedly to update client of the number of files written to the archive
++ (BOOL)createZipFileAtPath:(NSString *)path
+    withContentsOfDirectory:(NSString *)directoryPath
+        keepParentDirectory:(BOOL)keepParentDirectory
+           compressionLevel:(int)compressionLevel
+                   password:(nullable NSString *)password
+                        AES:(BOOL)aes
+               keepSymlinks:(BOOL)keeplinks
+                   useZip64:(BOOL)useZip64
+            progressHandler:(void(^ _Nullable)(NSUInteger entryNumber, NSUInteger total))progressHandler;
+
+
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
+
+/// Convenience initializer that creates a zip archive (in the zip64 format) with:
+/// *path* the path of the zip archive
+- (instancetype)initWithPath:(NSString *)path;
+
+/// Designated initializer that creates a zip archive with:
+/// *path* the path of the zip archive
+/// *useZip64* should the archive use the zip64 format (for extremely large zip files) or the older zip format
+- (instancetype)initWithPath:(NSString *)path useZip64:(BOOL)useZip64 NS_DESIGNATED_INITIALIZER;
+
 - (BOOL)open;
 - (BOOL)openForAppending;
 
@@ -133,7 +163,15 @@ typedef NS_ENUM(NSInteger, SSZipArchiveErrorCode) {
 /// write file
 - (BOOL)writeFile:(NSString *)path withPassword:(nullable NSString *)password;
 - (BOOL)writeFileAtPath:(NSString *)path withFileName:(nullable NSString *)fileName withPassword:(nullable NSString *)password;
+
+/// Writes a file to the zip archive
+///   *path* is the absolute path of the file to be compressed
+///   *fileName* is the relative name of the file that is stored within the zip, e.g. /folder/subfolder/text1.txt
+///   *compressionLevel* controls how much compression is used, e.g. Z_DEFAULT_COMPRESSION (from "zlib.h")
+///   *password* is optional
+///   *aes* encryption should not be used if compatibility with native macOS unzip and Archive Utility is required
 - (BOOL)writeFileAtPath:(NSString *)path withFileName:(nullable NSString *)fileName compressionLevel:(int)compressionLevel password:(nullable NSString *)password AES:(BOOL)aes;
+
 ///write symlink files
 - (BOOL)writeSymlinkFileAtPath:(NSString *)path withFileName:(nullable NSString *)fileName compressionLevel:(int)compressionLevel password:(nullable NSString *)password AES:(BOOL)aes;
 /// write data


### PR DESCRIPTION
New parameter for SSZipArchive: `useZip64`

The designated initializer for SSZipArchive can now take a `useZip64` parameter to determine whether all the files in the archive should be written with the zip64 format.

The old initializer (-initWithPath:) remains, and creates an archive that uses zip64 (as before).

Addresses bug #619 