### PR TITLE
Fixes Mac Catalyst build with bumped OS minimum requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .tvOS("15.4"),
         .macOS(.v10_15),
         .watchOS("8.4"),
+        .macCatalyst("13.0")
     ],
     products: [
         .library(name: "ZipArchive", targets: ["ZipArchive"]),


### PR DESCRIPTION
Without an explicit Mac Catalyst deployment target to match the macOS target, the prior minimum OS version bump breaks the build for Catalyst apps targeting macOS 10.15 and macOS 11 (which I guess are already covered by the security patch for [CVE-2018-25032](https://nvd.nist.gov/vuln/detail/cve-2018-25032)?). Mac apps generally need to target further back than the latest OS.

Could make sense to increase this from `.macCatalyst("13.0")` to a higher point release to be sure. Thoughts?