### PR TITLE
Tag 2.4.3 Linker Fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
                 .define("HAVE_ZLIB"),
             ],
             linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-no_application_extension"]),
                 .linkedLibrary("z"),
                 .linkedLibrary("iconv"),
                 .linkedFramework("Security"),


### PR DESCRIPTION
Based of tag version 2.4.3 that adds fix for 'linking against a dylib which is not safe for use in application extensions' warning.

Also, this needs to be merged into the master branch because SwiftPM only allows unsafeOptions for [dependencies specified by a commit hash](https://github.com/apple/swift-package-manager/blob/main/Sources/Workspace/Workspace.swift#L1023-L1026). They're not allowed for versioned dependencies.