### PR TITLE
Adding visionOS

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,6 +9,7 @@ on:
     tags:
       - '*'
 jobs:
+  # oldest targets
   macos-11:
     runs-on: ${{matrix.OS}}
     strategy:
@@ -17,7 +18,7 @@ jobs:
         OS: [macOS-11]
         SDK: ["macosx"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         pushd Example
@@ -37,37 +38,52 @@ jobs:
         CONFIGURATION="Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES"
         xcodebuild -workspace Example/ZipArchiveExample.xcworkspace -scheme $SCHEME -sdk $SDK -destination "$DESTINATION" -configuration $CONFIGURATION $USEMODERNBUILDSYSTEM test
 
-  macos-12:
+  # newest targets
+  macos-14:
     runs-on: ${{matrix.OS}}
     strategy:
       fail-fast: false
       matrix:
-        OS: [macOS-12]
-        SDK: ["appletvsimulator", "iphonesimulator"]
+        OS: [macOS-14]
+        SDK: ["appletvsimulator", "iphonesimulator", "watchsimulator", "xrsimulator"]
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.4.1'
-    - uses: actions/checkout@v1
+        xcode-version: '15.3.0'
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         pushd Example
         pod install
-        popd  
+        popd
     - name: Build and test
       run: |
         if [ ${{ matrix.SDK }} == "appletvsimulator" ]; then
           SCHEME="ObjectiveCExample_tvOS"
           SDK="appletvsimulator"
           PLATFORM="tvOS Simulator"
-          DEVICE="Apple TV 4K (at 1080p) (2nd generation)"
+          DEVICE="Apple TV 4K (3rd generation) (at 1080p)"
           DESTINATION="platform=$PLATFORM,name=$DEVICE"
         fi
         if [ ${{ matrix.SDK }} == "iphonesimulator" ]; then
           SCHEME="ObjectiveCExample_iOS"
           SDK="iphonesimulator"
           PLATFORM="iOS Simulator"
-          DEVICE="iPhone 13 Pro Max"
+          DEVICE="iPhone 15 Pro Max"
+          DESTINATION="platform=$PLATFORM,name=$DEVICE"
+        fi
+        if [ ${{ matrix.SDK }} == "watchsimulator" ]; then
+          SCHEME="ObjectiveCExample_watchOS"
+          SDK="watchsimulator"
+          PLATFORM="watchOS Simulator"
+          DEVICE="Apple Watch Ultra 2 (49mm)"
+          DESTINATION="platform=$PLATFORM,name=$DEVICE"
+        fi
+        if [ ${{ matrix.SDK }} == "xrsimulator" ]; then
+          SCHEME="ObjectiveCExample_visionOS"
+          SDK="xrsimulator"
+          PLATFORM="visionOS Simulator"
+          DEVICE="Apple Vision Pro"
           DESTINATION="platform=$PLATFORM,name=$DEVICE"
         fi
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -23,6 +23,14 @@ abstract_target 'core' do
     platform :tvos, '15.4'
   end
 
+  target 'ObjectiveCExampleTests_visionOS' do
+    platform :visionos, '1.0'
+  end
+
+  target 'ObjectiveCExampleTests_watchOS' do
+    platform :watchos, '8.4'
+  end
+
   target 'SwiftExample' do
     platform :ios, '15.5'
   end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - SSZipArchive (2.5.5)
+  - SSZipArchive (2.6.0)
 
 DEPENDENCIES:
   - SSZipArchive (from `..`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: ".."
 
 SPEC CHECKSUMS:
-  SSZipArchive: c69881e8ac5521f0e622291387add5f60f30f3c4
+  SSZipArchive: 8d7126064276d7938c2d50beb7aee9e24038d492
 
-PODFILE CHECKSUM: 570af5c3534cb262ca98be3dedfff7caa40f00ed
+PODFILE CHECKSUM: f72aa12c216b9028a1e05f38d3c62c3f6f602c06
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/Example/ZipArchiveExample.xcodeproj/project.pbxproj
+++ b/Example/ZipArchiveExample.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		37FF0CB91F853459006E4361 /* ProgressDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FF0CB71F853459006E4361 /* ProgressDelegate.m */; };
 		37FF0CBA1F853459006E4361 /* ProgressDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FF0CB71F853459006E4361 /* ProgressDelegate.m */; };
 		57AA942E1C28397000858D82 /* ZipArchive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57AA942D1C28397000858D82 /* ZipArchive.framework */; };
+		5CE44B849569EE560A91F4E9 /* Pods_core_ObjectiveCExampleTests_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A53C905D9BA6730E90C3A8 /* Pods_core_ObjectiveCExampleTests_watchOS.framework */; };
 		5FBB318220AF99BC003BA18F /* PathTraversal.zip in Resources */ = {isa = PBXBuildFile; fileRef = 5FBB318120AF99BC003BA18F /* PathTraversal.zip */; };
 		5FBB318320AF99C9003BA18F /* PathTraversal.zip in Resources */ = {isa = PBXBuildFile; fileRef = 5FBB318120AF99BC003BA18F /* PathTraversal.zip */; };
 		5FBB318420AF99CF003BA18F /* PathTraversal.zip in Resources */ = {isa = PBXBuildFile; fileRef = 5FBB318120AF99BC003BA18F /* PathTraversal.zip */; };
@@ -104,13 +105,61 @@
 		8DFE1A351BDAA10100709011 /* 6.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A251BDAA10100709011 /* 6.m4a */; };
 		8DFE1A361BDAA10100709011 /* 7.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A261BDAA10100709011 /* 7.m4a */; };
 		C2E3098D50AA6A2F41F8AB39 /* Pods_core_SwiftExample_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D745CAB61B0334919B9281E8 /* Pods_core_SwiftExample_macOS.framework */; };
+		C8345BE62BE568C200B60352 /* SSZipArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DFE1A071BDA9FF300709011 /* SSZipArchiveTests.m */; };
+		C8345BE72BE568C200B60352 /* ProgressDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FF0CB71F853459006E4361 /* ProgressDelegate.m */; };
+		C8345BE82BE568C200B60352 /* CollectingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DFE1A131BDAA0A800709011 /* CollectingDelegate.m */; };
+		C8345BE92BE568C200B60352 /* CancelDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FF0CB21F8533E0006E4361 /* CancelDelegate.m */; };
+		C8345BED2BE568C200B60352 /* PathTraversal.zip in Resources */ = {isa = PBXBuildFile; fileRef = 5FBB318120AF99BC003BA18F /* PathTraversal.zip */; };
+		C8345BEE2BE568C200B60352 /* 6.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A251BDAA10100709011 /* 6.m4a */; };
+		C8345BEF2BE568C200B60352 /* hello.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A161BDAA10100709011 /* hello.zip */; };
+		C8345BF02BE568C200B60352 /* PermissionsTestApp.app in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A181BDAA10100709011 /* PermissionsTestApp.app */; };
+		C8345BF12BE568C200B60352 /* Empty.zip in Resources */ = {isa = PBXBuildFile; fileRef = 3754B1311F88961800A58AA0 /* Empty.zip */; };
+		C8345BF22BE568C200B60352 /* TestArchive.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1B1BDAA10100709011 /* TestArchive.zip */; };
+		C8345BF32BE568C200B60352 /* 5.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A241BDAA10100709011 /* 5.m4a */; };
+		C8345BF42BE568C200B60352 /* 3.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A221BDAA10100709011 /* 3.m4a */; };
+		C8345BF52BE568C200B60352 /* RelativeSymbolicLink.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A191BDAA10100709011 /* RelativeSymbolicLink.zip */; };
+		C8345BF62BE568C200B60352 /* Unicode.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1D1BDAA10100709011 /* Unicode.zip */; };
+		C8345BF72BE568C200B60352 /* IncorrectHeaders.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A171BDAA10100709011 /* IncorrectHeaders.zip */; };
+		C8345BF82BE568C200B60352 /* TestPasswordArchive.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1C1BDAA10100709011 /* TestPasswordArchive.zip */; };
+		C8345BF92BE568C200B60352 /* 4.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A231BDAA10100709011 /* 4.m4a */; };
+		C8345BFA2BE568C200B60352 /* 7.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A261BDAA10100709011 /* 7.m4a */; };
+		C8345BFB2BE568C200B60352 /* 2.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A211BDAA10100709011 /* 2.m4a */; };
+		C8345BFC2BE568C200B60352 /* SymbolicLink.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1A1BDAA10100709011 /* SymbolicLink.zip */; };
+		C8345BFD2BE568C200B60352 /* 1.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A201BDAA10100709011 /* 1.m4a */; };
+		C8345BFE2BE568C200B60352 /* 0.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1F1BDAA10100709011 /* 0.m4a */; };
+		C8345BFF2BE568C200B60352 /* TestAESPasswordArchive.zip in Resources */ = {isa = PBXBuildFile; fileRef = 37CC960B2294F95600E71C3C /* TestAESPasswordArchive.zip */; };
+		C85BEF492BE55EA400ABAB8F /* SSZipArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DFE1A071BDA9FF300709011 /* SSZipArchiveTests.m */; };
+		C85BEF4A2BE55EA400ABAB8F /* ProgressDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FF0CB71F853459006E4361 /* ProgressDelegate.m */; };
+		C85BEF4B2BE55EA400ABAB8F /* CollectingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DFE1A131BDAA0A800709011 /* CollectingDelegate.m */; };
+		C85BEF4C2BE55EA400ABAB8F /* CancelDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FF0CB21F8533E0006E4361 /* CancelDelegate.m */; };
+		C85BEF502BE55EA400ABAB8F /* PathTraversal.zip in Resources */ = {isa = PBXBuildFile; fileRef = 5FBB318120AF99BC003BA18F /* PathTraversal.zip */; };
+		C85BEF512BE55EA400ABAB8F /* 6.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A251BDAA10100709011 /* 6.m4a */; };
+		C85BEF522BE55EA400ABAB8F /* hello.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A161BDAA10100709011 /* hello.zip */; };
+		C85BEF532BE55EA400ABAB8F /* PermissionsTestApp.app in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A181BDAA10100709011 /* PermissionsTestApp.app */; };
+		C85BEF542BE55EA400ABAB8F /* Empty.zip in Resources */ = {isa = PBXBuildFile; fileRef = 3754B1311F88961800A58AA0 /* Empty.zip */; };
+		C85BEF552BE55EA400ABAB8F /* TestArchive.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1B1BDAA10100709011 /* TestArchive.zip */; };
+		C85BEF562BE55EA400ABAB8F /* 5.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A241BDAA10100709011 /* 5.m4a */; };
+		C85BEF572BE55EA400ABAB8F /* 3.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A221BDAA10100709011 /* 3.m4a */; };
+		C85BEF582BE55EA400ABAB8F /* RelativeSymbolicLink.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A191BDAA10100709011 /* RelativeSymbolicLink.zip */; };
+		C85BEF592BE55EA400ABAB8F /* Unicode.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1D1BDAA10100709011 /* Unicode.zip */; };
+		C85BEF5A2BE55EA400ABAB8F /* IncorrectHeaders.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A171BDAA10100709011 /* IncorrectHeaders.zip */; };
+		C85BEF5B2BE55EA400ABAB8F /* TestPasswordArchive.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1C1BDAA10100709011 /* TestPasswordArchive.zip */; };
+		C85BEF5C2BE55EA400ABAB8F /* 4.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A231BDAA10100709011 /* 4.m4a */; };
+		C85BEF5D2BE55EA400ABAB8F /* 7.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A261BDAA10100709011 /* 7.m4a */; };
+		C85BEF5E2BE55EA400ABAB8F /* 2.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A211BDAA10100709011 /* 2.m4a */; };
+		C85BEF5F2BE55EA400ABAB8F /* SymbolicLink.zip in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1A1BDAA10100709011 /* SymbolicLink.zip */; };
+		C85BEF602BE55EA400ABAB8F /* 1.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A201BDAA10100709011 /* 1.m4a */; };
+		C85BEF612BE55EA400ABAB8F /* 0.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 8DFE1A1F1BDAA10100709011 /* 0.m4a */; };
+		C85BEF622BE55EA400ABAB8F /* TestAESPasswordArchive.zip in Resources */ = {isa = PBXBuildFile; fileRef = 37CC960B2294F95600E71C3C /* TestAESPasswordArchive.zip */; };
 		CC425A5DF3AE73723F6582F1 /* Pods_core_ObjectiveCExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F55AA2EC4D572A3D0AF90BA /* Pods_core_ObjectiveCExample.framework */; };
+		CF62025A6B48857633D59BA3 /* Pods_core_ObjectiveCExampleTests_visionOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3A1FA27B403DD333FFAFDA2 /* Pods_core_ObjectiveCExampleTests_visionOS.framework */; };
 		D2885233B35CC10CEC374D53 /* Pods_core_ObjectiveCExampleTests_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B24D4343DEE4228CB2E5423 /* Pods_core_ObjectiveCExampleTests_macOS.framework */; };
 		EACE0D328EB96FA347E3BBB7 /* Pods_core_ObjectiveCExampleTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DE06FF5ED20D6135954A07F /* Pods_core_ObjectiveCExampleTests_tvOS.framework */; };
 		F7D6D86D1CFB2C4900DA6DA6 /* Sample Data in Resources */ = {isa = PBXBuildFile; fileRef = F7D6D86C1CFB2C4900DA6DA6 /* Sample Data */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0F5B2FA612253A8A5D7BEE28 /* Pods-core-ObjectiveCExampleTests_visionOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExampleTests_visionOS.debug.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExampleTests_visionOS/Pods-core-ObjectiveCExampleTests_visionOS.debug.xcconfig"; sourceTree = "<group>"; };
 		1B9035B1B236217729CB7D16 /* Pods-core-ObjectiveCExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExample.debug.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExample/Pods-core-ObjectiveCExample.debug.xcconfig"; sourceTree = "<group>"; };
 		1DE06FF5ED20D6135954A07F /* Pods_core_ObjectiveCExampleTests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_core_ObjectiveCExampleTests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B4B24761C21500E00CC99E5 /* SwiftExampleCarthage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftExampleCarthage.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -134,10 +183,12 @@
 		37FF0CB71F853459006E4361 /* ProgressDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProgressDelegate.m; sourceTree = "<group>"; };
 		3BB772F308CFA3E4767C2658 /* Pods-core-SwiftExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-SwiftExample.release.xcconfig"; path = "Target Support Files/Pods-core-SwiftExample/Pods-core-SwiftExample.release.xcconfig"; sourceTree = "<group>"; };
 		48D5C61C213E97A4B17BACFA /* Pods_core_ObjectiveCExampleTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_core_ObjectiveCExampleTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		57A53C905D9BA6730E90C3A8 /* Pods_core_ObjectiveCExampleTests_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_core_ObjectiveCExampleTests_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57AA942D1C28397000858D82 /* ZipArchive.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZipArchive.framework; path = Carthage/Build/iOS/ZipArchive.framework; sourceTree = "<group>"; };
 		5FBB318120AF99BC003BA18F /* PathTraversal.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = PathTraversal.zip; sourceTree = "<group>"; };
 		5FF701DB4FB59433B4BD84C3 /* Pods-core-ObjectiveCExampleTests_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExampleTests_tvOS.debug.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExampleTests_tvOS/Pods-core-ObjectiveCExampleTests_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		71C8D36D6550EF30DECFB890 /* Pods-core-ObjectiveCExampleTests_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExampleTests_iOS.release.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExampleTests_iOS/Pods-core-ObjectiveCExampleTests_iOS.release.xcconfig"; sourceTree = "<group>"; };
+		7FC823CA134884B43B6C0C91 /* Pods-core-ObjectiveCExampleTests_visionOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExampleTests_visionOS.release.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExampleTests_visionOS/Pods-core-ObjectiveCExampleTests_visionOS.release.xcconfig"; sourceTree = "<group>"; };
 		8BE6F8A03ACEE48A4A0B6EA5 /* Pods-core-ObjectiveCExampleTests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExampleTests_iOS.debug.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExampleTests_iOS/Pods-core-ObjectiveCExampleTests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		8D9AE8B01FE79EABEDC1DA87 /* Pods_core_SwiftExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_core_SwiftExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8DFE19091BDA74F800709011 /* SwiftExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -179,10 +230,15 @@
 		8DFE1A251BDAA10100709011 /* 6.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = 6.m4a; sourceTree = "<group>"; };
 		8DFE1A261BDAA10100709011 /* 7.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = 7.m4a; sourceTree = "<group>"; };
 		8F55AA2EC4D572A3D0AF90BA /* Pods_core_ObjectiveCExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_core_ObjectiveCExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		92F48D7C38A622F433292827 /* Pods-core-ObjectiveCExampleTests_watchOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExampleTests_watchOS.debug.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExampleTests_watchOS/Pods-core-ObjectiveCExampleTests_watchOS.debug.xcconfig"; sourceTree = "<group>"; };
 		9AA4CAF9BE9A956B2CB426D8 /* Pods-core-ObjectiveCExampleTests_macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExampleTests_macOS.release.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExampleTests_macOS/Pods-core-ObjectiveCExampleTests_macOS.release.xcconfig"; sourceTree = "<group>"; };
 		9B24D4343DEE4228CB2E5423 /* Pods_core_ObjectiveCExampleTests_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_core_ObjectiveCExampleTests_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4B6FDB4D840506270E7881C /* Pods-core-ObjectiveCExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExample.release.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExample/Pods-core-ObjectiveCExample.release.xcconfig"; sourceTree = "<group>"; };
+		B3A1FA27B403DD333FFAFDA2 /* Pods_core_ObjectiveCExampleTests_visionOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_core_ObjectiveCExampleTests_visionOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0E7CEB707BDE066D061076E /* Pods-core-ObjectiveCExampleTests_watchOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-ObjectiveCExampleTests_watchOS.release.xcconfig"; path = "Target Support Files/Pods-core-ObjectiveCExampleTests_watchOS/Pods-core-ObjectiveCExampleTests_watchOS.release.xcconfig"; sourceTree = "<group>"; };
 		C803DFAF3E5379795284135A /* Pods-core-SwiftExample_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-SwiftExample_macOS.debug.xcconfig"; path = "Target Support Files/Pods-core-SwiftExample_macOS/Pods-core-SwiftExample_macOS.debug.xcconfig"; sourceTree = "<group>"; };
+		C8345C042BE568C200B60352 /* ObjectiveCExampleTests_visionOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectiveCExampleTests_visionOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C85BEF672BE55EA400ABAB8F /* ObjectiveCExampleTests_watchOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectiveCExampleTests_watchOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D269B6DE92A452B8E2CDF98D /* Pods-core-SwiftExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-core-SwiftExample.debug.xcconfig"; path = "Target Support Files/Pods-core-SwiftExample/Pods-core-SwiftExample.debug.xcconfig"; sourceTree = "<group>"; };
 		D745CAB61B0334919B9281E8 /* Pods_core_SwiftExample_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_core_SwiftExample_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7D6D86C1CFB2C4900DA6DA6 /* Sample Data */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Sample Data"; sourceTree = "<group>"; };
@@ -245,6 +301,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C8345BEA2BE568C200B60352 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CF62025A6B48857633D59BA3 /* Pods_core_ObjectiveCExampleTests_visionOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C85BEF4D2BE55EA400ABAB8F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5CE44B849569EE560A91F4E9 /* Pods_core_ObjectiveCExampleTests_watchOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -298,6 +370,8 @@
 				8DFE19091BDA74F800709011 /* SwiftExample.app */,
 				2B4B24761C21500E00CC99E5 /* SwiftExampleCarthage.app */,
 				37329A022273057300FEA32A /* SwiftExample_macOS.app */,
+				C85BEF672BE55EA400ABAB8F /* ObjectiveCExampleTests_watchOS.xctest */,
+				C8345C042BE568C200B60352 /* ObjectiveCExampleTests_visionOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -387,12 +461,15 @@
 				9AA4CAF9BE9A956B2CB426D8 /* Pods-core-ObjectiveCExampleTests_macOS.release.xcconfig */,
 				5FF701DB4FB59433B4BD84C3 /* Pods-core-ObjectiveCExampleTests_tvOS.debug.xcconfig */,
 				3562B8AAFD15D1657D5EFE76 /* Pods-core-ObjectiveCExampleTests_tvOS.release.xcconfig */,
+				0F5B2FA612253A8A5D7BEE28 /* Pods-core-ObjectiveCExampleTests_visionOS.debug.xcconfig */,
+				7FC823CA134884B43B6C0C91 /* Pods-core-ObjectiveCExampleTests_visionOS.release.xcconfig */,
+				92F48D7C38A622F433292827 /* Pods-core-ObjectiveCExampleTests_watchOS.debug.xcconfig */,
+				C0E7CEB707BDE066D061076E /* Pods-core-ObjectiveCExampleTests_watchOS.release.xcconfig */,
 				D269B6DE92A452B8E2CDF98D /* Pods-core-SwiftExample.debug.xcconfig */,
 				3BB772F308CFA3E4767C2658 /* Pods-core-SwiftExample.release.xcconfig */,
 				C803DFAF3E5379795284135A /* Pods-core-SwiftExample_macOS.debug.xcconfig */,
 				31C482431F08926C4CF26EEE /* Pods-core-SwiftExample_macOS.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -404,6 +481,8 @@
 				48D5C61C213E97A4B17BACFA /* Pods_core_ObjectiveCExampleTests_iOS.framework */,
 				9B24D4343DEE4228CB2E5423 /* Pods_core_ObjectiveCExampleTests_macOS.framework */,
 				1DE06FF5ED20D6135954A07F /* Pods_core_ObjectiveCExampleTests_tvOS.framework */,
+				B3A1FA27B403DD333FFAFDA2 /* Pods_core_ObjectiveCExampleTests_visionOS.framework */,
+				57A53C905D9BA6730E90C3A8 /* Pods_core_ObjectiveCExampleTests_watchOS.framework */,
 				8D9AE8B01FE79EABEDC1DA87 /* Pods_core_SwiftExample.framework */,
 				D745CAB61B0334919B9281E8 /* Pods_core_SwiftExample_macOS.framework */,
 			);
@@ -545,6 +624,44 @@
 			productReference = 8DFE1A031BDA9FF300709011 /* ObjectiveCExampleTests_iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		C8345BE32BE568C200B60352 /* ObjectiveCExampleTests_visionOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C8345C012BE568C200B60352 /* Build configuration list for PBXNativeTarget "ObjectiveCExampleTests_visionOS" */;
+			buildPhases = (
+				C8345BE42BE568C200B60352 /* [CP] Check Pods Manifest.lock */,
+				C8345BE52BE568C200B60352 /* Sources */,
+				C8345BEA2BE568C200B60352 /* Frameworks */,
+				C8345BEC2BE568C200B60352 /* Resources */,
+				C8345C002BE568C200B60352 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ObjectiveCExampleTests_visionOS;
+			productName = ObjectiveCExampleTests_tvOS;
+			productReference = C8345C042BE568C200B60352 /* ObjectiveCExampleTests_visionOS.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		C85BEF462BE55EA400ABAB8F /* ObjectiveCExampleTests_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C85BEF642BE55EA400ABAB8F /* Build configuration list for PBXNativeTarget "ObjectiveCExampleTests_watchOS" */;
+			buildPhases = (
+				C85BEF472BE55EA400ABAB8F /* [CP] Check Pods Manifest.lock */,
+				C85BEF482BE55EA400ABAB8F /* Sources */,
+				C85BEF4D2BE55EA400ABAB8F /* Frameworks */,
+				C85BEF4F2BE55EA400ABAB8F /* Resources */,
+				C85BEF632BE55EA400ABAB8F /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ObjectiveCExampleTests_watchOS;
+			productName = ObjectiveCExampleTests_tvOS;
+			productReference = C85BEF672BE55EA400ABAB8F /* ObjectiveCExampleTests_watchOS.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -581,6 +698,12 @@
 						CreatedOnToolsVersion = 7.1;
 						ProvisioningStyle = Automatic;
 					};
+					C8345BE32BE568C200B60352 = {
+						ProvisioningStyle = Automatic;
+					};
+					C85BEF462BE55EA400ABAB8F = {
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 8DFE19E51BDA9FF300709011 /* Build configuration list for PBXProject "ZipArchiveExample" */;
@@ -600,6 +723,8 @@
 				8DFE1A021BDA9FF300709011 /* ObjectiveCExampleTests_iOS */,
 				3773ADAD1F7F44D8009A4B2D /* ObjectiveCExampleTests_macOS */,
 				3793E6D61F7F5F93000B1A19 /* ObjectiveCExampleTests_tvOS */,
+				C8345BE32BE568C200B60352 /* ObjectiveCExampleTests_visionOS */,
+				C85BEF462BE55EA400ABAB8F /* ObjectiveCExampleTests_watchOS */,
 				8DFE19081BDA74F800709011 /* SwiftExample */,
 				37329A012273057300FEA32A /* SwiftExample_macOS */,
 				2B4B24641C21500E00CC99E5 /* SwiftExampleCarthage */,
@@ -727,6 +852,58 @@
 				8DFE1A2B1BDAA10100709011 /* SymbolicLink.zip in Resources */,
 				8DFE1A291BDAA10100709011 /* PermissionsTestApp.app in Resources */,
 				37CC960C2294F96100E71C3C /* TestAESPasswordArchive.zip in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C8345BEC2BE568C200B60352 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8345BED2BE568C200B60352 /* PathTraversal.zip in Resources */,
+				C8345BEE2BE568C200B60352 /* 6.m4a in Resources */,
+				C8345BEF2BE568C200B60352 /* hello.zip in Resources */,
+				C8345BF02BE568C200B60352 /* PermissionsTestApp.app in Resources */,
+				C8345BF12BE568C200B60352 /* Empty.zip in Resources */,
+				C8345BF22BE568C200B60352 /* TestArchive.zip in Resources */,
+				C8345BF32BE568C200B60352 /* 5.m4a in Resources */,
+				C8345BF42BE568C200B60352 /* 3.m4a in Resources */,
+				C8345BF52BE568C200B60352 /* RelativeSymbolicLink.zip in Resources */,
+				C8345BF62BE568C200B60352 /* Unicode.zip in Resources */,
+				C8345BF72BE568C200B60352 /* IncorrectHeaders.zip in Resources */,
+				C8345BF82BE568C200B60352 /* TestPasswordArchive.zip in Resources */,
+				C8345BF92BE568C200B60352 /* 4.m4a in Resources */,
+				C8345BFA2BE568C200B60352 /* 7.m4a in Resources */,
+				C8345BFB2BE568C200B60352 /* 2.m4a in Resources */,
+				C8345BFC2BE568C200B60352 /* SymbolicLink.zip in Resources */,
+				C8345BFD2BE568C200B60352 /* 1.m4a in Resources */,
+				C8345BFE2BE568C200B60352 /* 0.m4a in Resources */,
+				C8345BFF2BE568C200B60352 /* TestAESPasswordArchive.zip in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C85BEF4F2BE55EA400ABAB8F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C85BEF502BE55EA400ABAB8F /* PathTraversal.zip in Resources */,
+				C85BEF512BE55EA400ABAB8F /* 6.m4a in Resources */,
+				C85BEF522BE55EA400ABAB8F /* hello.zip in Resources */,
+				C85BEF532BE55EA400ABAB8F /* PermissionsTestApp.app in Resources */,
+				C85BEF542BE55EA400ABAB8F /* Empty.zip in Resources */,
+				C85BEF552BE55EA400ABAB8F /* TestArchive.zip in Resources */,
+				C85BEF562BE55EA400ABAB8F /* 5.m4a in Resources */,
+				C85BEF572BE55EA400ABAB8F /* 3.m4a in Resources */,
+				C85BEF582BE55EA400ABAB8F /* RelativeSymbolicLink.zip in Resources */,
+				C85BEF592BE55EA400ABAB8F /* Unicode.zip in Resources */,
+				C85BEF5A2BE55EA400ABAB8F /* IncorrectHeaders.zip in Resources */,
+				C85BEF5B2BE55EA400ABAB8F /* TestPasswordArchive.zip in Resources */,
+				C85BEF5C2BE55EA400ABAB8F /* 4.m4a in Resources */,
+				C85BEF5D2BE55EA400ABAB8F /* 7.m4a in Resources */,
+				C85BEF5E2BE55EA400ABAB8F /* 2.m4a in Resources */,
+				C85BEF5F2BE55EA400ABAB8F /* SymbolicLink.zip in Resources */,
+				C85BEF602BE55EA400ABAB8F /* 1.m4a in Resources */,
+				C85BEF612BE55EA400ABAB8F /* 0.m4a in Resources */,
+				C85BEF622BE55EA400ABAB8F /* TestAESPasswordArchive.zip in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -926,6 +1103,86 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-core-SwiftExample_macOS/Pods-core-SwiftExample_macOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		C8345BE42BE568C200B60352 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-core-ObjectiveCExampleTests_visionOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C8345C002BE568C200B60352 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-core-ObjectiveCExampleTests_visionOS/Pods-core-ObjectiveCExampleTests_visionOS-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/SSZipArchive-visionOS/SSZipArchive.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-core-ObjectiveCExampleTests_visionOS/Pods-core-ObjectiveCExampleTests_visionOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C85BEF472BE55EA400ABAB8F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-core-ObjectiveCExampleTests_watchOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C85BEF632BE55EA400ABAB8F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-core-ObjectiveCExampleTests_watchOS/Pods-core-ObjectiveCExampleTests_watchOS-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/SSZipArchive-watchOS/SSZipArchive.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSZipArchive.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-core-ObjectiveCExampleTests_watchOS/Pods-core-ObjectiveCExampleTests_watchOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		D0DFCD28F5F6FDDAA2685A0B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1058,6 +1315,28 @@
 				37FF0CB81F853459006E4361 /* ProgressDelegate.m in Sources */,
 				8DFE1A081BDA9FF300709011 /* SSZipArchiveTests.m in Sources */,
 				37FF0CB31F8533E0006E4361 /* CancelDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C8345BE52BE568C200B60352 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8345BE62BE568C200B60352 /* SSZipArchiveTests.m in Sources */,
+				C8345BE72BE568C200B60352 /* ProgressDelegate.m in Sources */,
+				C8345BE82BE568C200B60352 /* CollectingDelegate.m in Sources */,
+				C8345BE92BE568C200B60352 /* CancelDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C85BEF482BE55EA400ABAB8F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C85BEF492BE55EA400ABAB8F /* SSZipArchiveTests.m in Sources */,
+				C85BEF4A2BE55EA400ABAB8F /* ProgressDelegate.m in Sources */,
+				C85BEF4B2BE55EA400ABAB8F /* CollectingDelegate.m in Sources */,
+				C85BEF4C2BE55EA400ABAB8F /* CancelDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1202,6 +1481,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				INFOPLIST_FILE = SwiftExample_macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -1222,6 +1502,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = ObjectiveCExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -1347,6 +1628,8 @@
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 15.4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.4;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Debug;
 		};
@@ -1410,6 +1693,8 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 15.4;
 				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 8.4;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;
 		};
@@ -1467,6 +1752,70 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ziparchive.ObjectiveCExampleTests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		C8345C022BE568C200B60352 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0F5B2FA612253A8A5D7BEE28 /* Pods-core-ObjectiveCExampleTests_visionOS.debug.xcconfig */;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ObjectiveCExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ziparchive.ObjectiveCExampleTests-visionOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				TARGETED_DEVICE_FAMILY = 7;
+			};
+			name = Debug;
+		};
+		C8345C032BE568C200B60352 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7FC823CA134884B43B6C0C91 /* Pods-core-ObjectiveCExampleTests_visionOS.release.xcconfig */;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ObjectiveCExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ziparchive.ObjectiveCExampleTests-visionOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				TARGETED_DEVICE_FAMILY = 7;
+			};
+			name = Release;
+		};
+		C85BEF652BE55EA400ABAB8F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 92F48D7C38A622F433292827 /* Pods-core-ObjectiveCExampleTests_watchOS.debug.xcconfig */;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ObjectiveCExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ziparchive.ObjectiveCExampleTests-watchOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = Debug;
+		};
+		C85BEF662BE55EA400ABAB8F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C0E7CEB707BDE066D061076E /* Pods-core-ObjectiveCExampleTests_watchOS.release.xcconfig */;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ObjectiveCExampleTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ziparchive.ObjectiveCExampleTests-watchOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = Release;
 		};
@@ -1541,6 +1890,24 @@
 			buildConfigurations = (
 				8DFE1A101BDA9FF300709011 /* Debug */,
 				8DFE1A111BDA9FF300709011 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C8345C012BE568C200B60352 /* Build configuration list for PBXNativeTarget "ObjectiveCExampleTests_visionOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C8345C022BE568C200B60352 /* Debug */,
+				C8345C032BE568C200B60352 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C85BEF642BE55EA400ABAB8F /* Build configuration list for PBXNativeTarget "ObjectiveCExampleTests_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C85BEF652BE55EA400ABAB8F /* Debug */,
+				C85BEF662BE55EA400ABAB8F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_visionOS.xcscheme
+++ b/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_visionOS.xcscheme
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C8345BE32BE568C200B60352"
+               BuildableName = "ObjectiveCExampleTests_visionOS.xctest"
+               BlueprintName = "ObjectiveCExampleTests_visionOS"
+               ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_watchOS.xcscheme
+++ b/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_watchOS.xcscheme
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C85BEF462BE55EA400ABAB8F"
+               BuildableName = "ObjectiveCExampleTests_watchOS.xctest"
+               BlueprintName = "ObjectiveCExampleTests_watchOS"
+               ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,6 +9,7 @@ let package = Package(
         .iOS("15.5"),
         .tvOS("15.4"),
         .macOS(.v10_15),
+        .visionOS("1.0"),
         .watchOS("8.4"),
         .macCatalyst("13.0")
     ],

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SSZipArchive
 
-ZipArchive is a simple utility class for zipping and unzipping files on iOS, macOS and tvOS.
+ZipArchive is a simple utility class for zipping and unzipping files on iOS, macOS, tvOS, watchOS and visionOS.
 
 - Unzip zip files;
 - Unzip password protected zip files;
@@ -26,10 +26,15 @@ We will not support versions of ZipArchive that use dependencies with known vuln
 
 ## Installation and Setup
 
-
 *The main release branch is configured to support Objective-C and Swift 4+.*
 
-SSZipArchive works on Xcode 12 and above, iOS 15.5 and above, tvOS 15.4 and above, macOS 10.15 and above, watchOS 8.4 and above.
+SSZipArchive works on:
+- Xcode 12 and above
+- iOS 15.5 and above
+- macOS 10.15 and above
+- tvOS 15.4 and above
+- visionOS 1.0 and above
+- watchOS 8.4 and above
 
 ### CocoaPods
 In your Podfile:  
@@ -87,7 +92,7 @@ SSZipArchive.unzipFileAtPath(zipPath, toDestination: unzipPath)
 
 ## License
 
-SSZipArchive is protected under the [MIT license](https://github.com/samsoffes/ssziparchive/raw/master/LICENSE) and our slightly modified version of [minizip-ng (formally minizip)](https://github.com/zlib-ng/minizip-ng) 3.0.6 is licensed under the [Zlib license](https://www.zlib.net/zlib_license.html).
+SSZipArchive is protected under the [MIT license](https://github.com/samsoffes/ssziparchive/raw/master/LICENSE) and our slightly modified version of [minizip-ng (formally minizip)](https://github.com/zlib-ng/minizip-ng) 3.0.10 is licensed under the [Zlib license](https://www.zlib.net/zlib_license.html).
 
 ## Acknowledgments
 

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -1,15 +1,16 @@
 Pod::Spec.new do |s|
   s.name         = 'SSZipArchive'
-  s.version      = '2.5.5'
-  s.summary      = 'Utility class for zipping and unzipping files on iOS, tvOS, watchOS, and macOS.'
-  s.description  = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS, tvOS, watchOS, and macOS. It supports AES and PKWARE encryption.'
+  s.version      = '2.6.0'
+  s.summary      = 'Utility class for zipping and unzipping files on iOS, tvOS, visionOS, watchOS, and macOS.'
+  s.description  = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS, tvOS, visionOS, watchOS, and macOS. It supports AES and PKWARE encryption.'
   s.homepage     = 'https://github.com/ZipArchive/ZipArchive'
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
   s.authors      = { 'Sam Soffes' => 'sam@soff.es', 'Joshua Hudson' => nil, 'Wilson Chen' => nil }
   s.source       = { :git => 'https://github.com/ZipArchive/ZipArchive.git', :tag => "#{s.version}" }
   s.ios.deployment_target = '15.5'
-  s.tvos.deployment_target = '15.4'
   s.osx.deployment_target = '10.15'
+  s.tvos.deployment_target = '15.4'
+  s.visionos.deployment_target = '1.0'
   s.watchos.deployment_target = '8.4'
   s.source_files = 'SSZipArchive/*.{m,h}', 'SSZipArchive/include/*.{m,h}', 'SSZipArchive/minizip/*.{c,h}'
   s.resource_bundles = {'SSZipArchive' => ['SSZipArchive/Supporting Files/Privacyinfo.xcprivacy']}

--- a/SSZipArchive/Supporting Files/PrivacyInfo.xcprivacy
+++ b/SSZipArchive/Supporting Files/PrivacyInfo.xcprivacy
@@ -15,7 +15,7 @@
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>C617.1</string>
+				<string>0A2A.1</string>
 			</array>
 		</dict>
 	</array>

--- a/ZipArchive.xcodeproj/project.pbxproj
+++ b/ZipArchive.xcodeproj/project.pbxproj
@@ -155,6 +155,43 @@
 		B423AE6B1C0DF7950004A2F1 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE481C0DF7950004A2F1 /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B423AE6C1C0DF7950004A2F1 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = B423AE491C0DF7950004A2F1 /* SSZipArchive.m */; };
 		B423AE6D1C0DF7950004A2F1 /* ZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE4A1C0DF7950004A2F1 /* ZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C8DEE3662BE59172005150F4 /* mz_os_posix.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F33E2276B14300A1840B /* mz_os_posix.c */; };
+		C8DEE3672BE59172005150F4 /* mz_strm_mem.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3342276B14200A1840B /* mz_strm_mem.c */; };
+		C8DEE3682BE59172005150F4 /* mz_strm_wzaes.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3482276B14400A1840B /* mz_strm_wzaes.c */; };
+		C8DEE3692BE59172005150F4 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = B423AE491C0DF7950004A2F1 /* SSZipArchive.m */; };
+		C8DEE36A2BE59172005150F4 /* mz_zip.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F33C2276B14300A1840B /* mz_zip.c */; };
+		C8DEE36B2BE59172005150F4 /* mz_crypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F32E2276B14200A1840B /* mz_crypt.c */; };
+		C8DEE36C2BE59172005150F4 /* mz_strm_split.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3362276B14200A1840B /* mz_strm_split.c */; };
+		C8DEE36D2BE59172005150F4 /* mz_strm_pkcrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3252276B14100A1840B /* mz_strm_pkcrypt.c */; };
+		C8DEE36E2BE59172005150F4 /* mz_strm.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3462276B14300A1840B /* mz_strm.c */; };
+		C8DEE36F2BE59172005150F4 /* mz_compat.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3282276B14100A1840B /* mz_compat.c */; };
+		C8DEE3702BE59172005150F4 /* mz_crypt_apple.c in Sources */ = {isa = PBXBuildFile; fileRef = 378439B1227ABC7B000BC165 /* mz_crypt_apple.c */; };
+		C8DEE3712BE59172005150F4 /* mz_strm_zlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F33A2276B14200A1840B /* mz_strm_zlib.c */; };
+		C8DEE3722BE59172005150F4 /* mz_zip_rw.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3332276B14200A1840B /* mz_zip_rw.c */; };
+		C8DEE3732BE59172005150F4 /* mz_os.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F32B2276B14200A1840B /* mz_os.c */; };
+		C8DEE3742BE59172005150F4 /* mz_strm_os_posix.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3432276B14300A1840B /* mz_strm_os_posix.c */; };
+		C8DEE3752BE59172005150F4 /* mz_strm_buf.c in Sources */ = {isa = PBXBuildFile; fileRef = 3775F3392276B14200A1840B /* mz_strm_buf.c */; };
+		C8DEE3772BE59172005150F4 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 378439C9227AC02B000BC165 /* libiconv.tbd */; };
+		C8DEE3782BE59172005150F4 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 378439CB227AC031000BC165 /* libz.tbd */; };
+		C8DEE3792BE59172005150F4 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 378439B6227ABD2B000BC165 /* Security.framework */; };
+		C8DEE37B2BE59172005150F4 /* mz_strm_zlib.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F3452276B14300A1840B /* mz_strm_zlib.h */; };
+		C8DEE37C2BE59172005150F4 /* mz_strm.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F33B2276B14200A1840B /* mz_strm.h */; };
+		C8DEE37D2BE59172005150F4 /* mz_strm_buf.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F33D2276B14300A1840B /* mz_strm_buf.h */; };
+		C8DEE37E2BE59172005150F4 /* mz_os.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F32F2276B14200A1840B /* mz_os.h */; };
+		C8DEE37F2BE59172005150F4 /* mz.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F32C2276B14200A1840B /* mz.h */; };
+		C8DEE3802BE59172005150F4 /* mz_crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F33F2276B14300A1840B /* mz_crypt.h */; };
+		C8DEE3812BE59172005150F4 /* mz_strm_split.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F3312276B14200A1840B /* mz_strm_split.h */; };
+		C8DEE3822BE59172005150F4 /* mz_zip.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F3412276B14300A1840B /* mz_zip.h */; };
+		C8DEE3832BE59172005150F4 /* mz_strm_mem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F3422276B14300A1840B /* mz_strm_mem.h */; };
+		C8DEE3842BE59172005150F4 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE481C0DF7950004A2F1 /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C8DEE3852BE59172005150F4 /* mz_strm_pkcrypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F3352276B14200A1840B /* mz_strm_pkcrypt.h */; };
+		C8DEE3862BE59172005150F4 /* ZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE4A1C0DF7950004A2F1 /* ZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C8DEE3872BE59172005150F4 /* mz_strm_os.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F32A2276B14100A1840B /* mz_strm_os.h */; };
+		C8DEE3882BE59172005150F4 /* mz_zip_rw.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F3382276B14200A1840B /* mz_zip_rw.h */; };
+		C8DEE3892BE59172005150F4 /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C8DEE38A2BE59172005150F4 /* mz_compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F3372276B14200A1840B /* mz_compat.h */; };
+		C8DEE38B2BE59172005150F4 /* mz_strm_wzaes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3775F3322276B14200A1840B /* mz_strm_wzaes.h */; };
+		C8DEE38D2BE59172005150F4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 330100222AC89AA8001431B0 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -209,6 +246,7 @@
 		B423AE481C0DF7950004A2F1 /* SSZipArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSZipArchive.h; sourceTree = "<group>"; };
 		B423AE491C0DF7950004A2F1 /* SSZipArchive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SSZipArchive.m; sourceTree = "<group>"; };
 		B423AE4A1C0DF7950004A2F1 /* ZipArchive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZipArchive.h; sourceTree = "<group>"; };
+		C8DEE3912BE59172005150F4 /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -249,6 +287,16 @@
 				3775F4262276C5C100A1840B /* libiconv.tbd in Frameworks */,
 				3775F4282276C5D500A1840B /* libz.tbd in Frameworks */,
 				378439C0227ABDDF000BC165 /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C8DEE3762BE59172005150F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8DEE3772BE59172005150F4 /* libiconv.tbd in Frameworks */,
+				C8DEE3782BE59172005150F4 /* libz.tbd in Frameworks */,
+				C8DEE3792BE59172005150F4 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -306,6 +354,7 @@
 				AFF75A241C37279600F450AC /* ZipArchive.framework */,
 				37952C261F63B50D00DD6677 /* ZipArchive.framework */,
 				37952C5E1F63BB7100DD6677 /* ZipArchive.framework */,
+				C8DEE3912BE59172005150F4 /* ZipArchive.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -459,6 +508,30 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C8DEE37A2BE59172005150F4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8DEE37B2BE59172005150F4 /* mz_strm_zlib.h in Headers */,
+				C8DEE37C2BE59172005150F4 /* mz_strm.h in Headers */,
+				C8DEE37D2BE59172005150F4 /* mz_strm_buf.h in Headers */,
+				C8DEE37E2BE59172005150F4 /* mz_os.h in Headers */,
+				C8DEE37F2BE59172005150F4 /* mz.h in Headers */,
+				C8DEE3802BE59172005150F4 /* mz_crypt.h in Headers */,
+				C8DEE3812BE59172005150F4 /* mz_strm_split.h in Headers */,
+				C8DEE3822BE59172005150F4 /* mz_zip.h in Headers */,
+				C8DEE3832BE59172005150F4 /* mz_strm_mem.h in Headers */,
+				C8DEE3842BE59172005150F4 /* SSZipArchive.h in Headers */,
+				C8DEE3852BE59172005150F4 /* mz_strm_pkcrypt.h in Headers */,
+				C8DEE3862BE59172005150F4 /* ZipArchive.h in Headers */,
+				C8DEE3872BE59172005150F4 /* mz_strm_os.h in Headers */,
+				C8DEE3882BE59172005150F4 /* mz_zip_rw.h in Headers */,
+				C8DEE3892BE59172005150F4 /* SSZipCommon.h in Headers */,
+				C8DEE38A2BE59172005150F4 /* mz_compat.h in Headers */,
+				C8DEE38B2BE59172005150F4 /* mz_strm_wzaes.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -534,6 +607,24 @@
 			productReference = B423AE1A1C0DF76A0004A2F1 /* ZipArchive.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		C8DEE3642BE59172005150F4 /* ZipArchive-visionos */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C8DEE38E2BE59172005150F4 /* Build configuration list for PBXNativeTarget "ZipArchive-visionos" */;
+			buildPhases = (
+				C8DEE3652BE59172005150F4 /* Sources */,
+				C8DEE3762BE59172005150F4 /* Frameworks */,
+				C8DEE37A2BE59172005150F4 /* Headers */,
+				C8DEE38C2BE59172005150F4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ZipArchive-visionos";
+			productName = ZipArchive;
+			productReference = C8DEE3912BE59172005150F4 /* ZipArchive.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -575,6 +666,7 @@
 				B423AE191C0DF76A0004A2F1 /* ZipArchive-iOS */,
 				AFF75A231C37279600F450AC /* ZipArchive-Mac */,
 				37952C251F63B50D00DD6677 /* ZipArchive-tvos */,
+				C8DEE3642BE59172005150F4 /* ZipArchive-visionos */,
 				37952C5D1F63BB7100DD6677 /* ZipArchive-watchos */,
 			);
 		};
@@ -610,6 +702,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				330100232AC89AA8001431B0 /* PrivacyInfo.xcprivacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C8DEE38C2BE59172005150F4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8DEE38D2BE59172005150F4 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -708,12 +808,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C8DEE3652BE59172005150F4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8DEE3662BE59172005150F4 /* mz_os_posix.c in Sources */,
+				C8DEE3672BE59172005150F4 /* mz_strm_mem.c in Sources */,
+				C8DEE3682BE59172005150F4 /* mz_strm_wzaes.c in Sources */,
+				C8DEE3692BE59172005150F4 /* SSZipArchive.m in Sources */,
+				C8DEE36A2BE59172005150F4 /* mz_zip.c in Sources */,
+				C8DEE36B2BE59172005150F4 /* mz_crypt.c in Sources */,
+				C8DEE36C2BE59172005150F4 /* mz_strm_split.c in Sources */,
+				C8DEE36D2BE59172005150F4 /* mz_strm_pkcrypt.c in Sources */,
+				C8DEE36E2BE59172005150F4 /* mz_strm.c in Sources */,
+				C8DEE36F2BE59172005150F4 /* mz_compat.c in Sources */,
+				C8DEE3702BE59172005150F4 /* mz_crypt_apple.c in Sources */,
+				C8DEE3712BE59172005150F4 /* mz_strm_zlib.c in Sources */,
+				C8DEE3722BE59172005150F4 /* mz_zip_rw.c in Sources */,
+				C8DEE3732BE59172005150F4 /* mz_os.c in Sources */,
+				C8DEE3742BE59172005150F4 /* mz_strm_os_posix.c in Sources */,
+				C8DEE3752BE59172005150F4 /* mz_strm_buf.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
 		37952C2B1F63B50D00DD6677 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
@@ -738,6 +862,7 @@
 		37952C2C1F63B50D00DD6677 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
@@ -818,8 +943,10 @@
 		AFF75A2A1C37279600F450AC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -839,9 +966,11 @@
 		AFF75A2B1C37279600F450AC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -913,7 +1042,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -975,7 +1103,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1033,6 +1160,61 @@
 			};
 			name = Release;
 		};
+		C8DEE38F2BE59172005150F4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = SSZipArchive/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = xros;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Debug;
+		};
+		C8DEE3902BE59172005150F4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = SSZipArchive/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = xros;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1077,6 +1259,15 @@
 			buildConfigurations = (
 				B423AE231C0DF76A0004A2F1 /* Debug */,
 				B423AE241C0DF76A0004A2F1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C8DEE38E2BE59172005150F4 /* Build configuration list for PBXNativeTarget "ZipArchive-visionos" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C8DEE38F2BE59172005150F4 /* Debug */,
+				C8DEE3902BE59172005150F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-visionos.xcscheme
+++ b/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-visionos.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C8DEE3642BE59172005150F4"
+               BuildableName = "ZipArchive-visionos.framework"
+               BlueprintName = "ZipArchive-visionos"
+               ReferencedContainer = "container:ZipArchive.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C8DEE3642BE59172005150F4"
+            BuildableName = "ZipArchive-visionos.framework"
+            BlueprintName = "ZipArchive-visionos"
+            ReferencedContainer = "container:ZipArchive.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Two small "breaking" changes:
1. Swift minimum version goes from 5.5 to 5.9 for visionOS support in Package.Swift
2. PrivacyInfo reason modified from C617.1 (only files inside the app container) to 0A2A.1 (any files, we're a third-party SDK): https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api

Hence, bumping version to ZipArchive 2.6.0.