### PR TITLE
Moving GitHub actions from macOS 11 to 12

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,13 +9,15 @@ on:
     tags:
       - '*'
 jobs:
+  # available images: https://github.com/actions/runner-images
+  
   # oldest targets
-  macos-11:
+  macos-12:
     runs-on: ${{matrix.OS}}
     strategy:
       fail-fast: false
       matrix:
-        OS: [macOS-11]
+        OS: [macOS-12]
         SDK: ["macosx"]
     steps:
     - uses: actions/checkout@v4
@@ -26,17 +28,16 @@ jobs:
         popd  
     - name: Build and test
       run: |
-        echo "Disabling modern build system as a workaround for target issue in Xcode 10+"
-        USEMODERNBUILDSYSTEM="-UseModernBuildSystem=NO"
         if [ ${{ matrix.SDK }} == "macosx" ]; then
           SCHEME="ObjectiveCExample_macOS"
-          SDK="macosx"
-          DESTINATION="platform=macosx"
+          PLATFORM="macOS"
+          ARCH="x86_64"
+          DESTINATION="platform=$PLATFORM,arch=$ARCH"
         fi
         
         # build and test
         CONFIGURATION="Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES"
-        xcodebuild -workspace Example/ZipArchiveExample.xcworkspace -scheme $SCHEME -sdk $SDK -destination "$DESTINATION" -configuration $CONFIGURATION $USEMODERNBUILDSYSTEM test
+        xcodebuild -workspace Example/ZipArchiveExample.xcworkspace -scheme $SCHEME -destination "$DESTINATION" -configuration $CONFIGURATION test
 
   # newest targets
   macos-14:
@@ -49,7 +50,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.3.0'
+        xcode-version: '15.4.0'
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
@@ -89,4 +90,4 @@ jobs:
 
         # build and test
         CONFIGURATION="Debug ONLY_ACTIVE_ARCH=NO ENABLE_TESTABILITY=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES"
-        xcodebuild -workspace Example/ZipArchiveExample.xcworkspace -scheme $SCHEME -sdk $SDK -destination "$DESTINATION" -configuration $CONFIGURATION $USEMODERNBUILDSYSTEM test
+        xcodebuild -workspace Example/ZipArchiveExample.xcworkspace -scheme $SCHEME -sdk $SDK -destination "$DESTINATION" -configuration $CONFIGURATION test

--- a/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_iOS.xcscheme
+++ b/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_iOS.xcscheme
@@ -1,38 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "2.2">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "NO"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DFE19E91BDA9FF300709011"
-               BuildableName = "ObjectiveCExample.app"
-               BlueprintName = "ObjectiveCExample"
-               ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DFE1A021BDA9FF300709011"
-               BuildableName = "ObjectiveCExampleTests_iOS.xctest"
-               BlueprintName = "ObjectiveCExampleTests_iOS"
-               ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
-            </BuildableReference>
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
@@ -40,7 +22,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -64,23 +47,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8DFE19E91BDA9FF300709011"
-            BuildableName = "ObjectiveCExample.app"
-            BlueprintName = "ObjectiveCExample"
-            ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "${DEBUG_ACTIVITY_MODE}"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -88,16 +54,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8DFE19E91BDA9FF300709011"
-            BuildableName = "ObjectiveCExample.app"
-            BlueprintName = "ObjectiveCExample"
-            ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_tvOS.xcscheme
+++ b/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_tvOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "2.2">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -12,13 +13,8 @@
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3793E6D61F7F5F93000B1A19"
-               BuildableName = "ObjectiveCExampleTests_tvOS.xctest"
-               BlueprintName = "ObjectiveCExampleTests_tvOS"
-               ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
-            </BuildableReference>
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
@@ -26,7 +22,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_visionOS.xcscheme
+++ b/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_visionOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1600"
    version = "2.2">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_watchOS.xcscheme
+++ b/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/ObjectiveCExample_watchOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1600"
    version = "2.2">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/SwiftExample_iOS.xcscheme
+++ b/Example/ZipArchiveExample.xcodeproj/xcshareddata/xcschemes/SwiftExample_iOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,19 +27,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8DFE191C1BDA74F800709011"
-               BuildableName = "SwiftExampleTests.xctest"
-               BlueprintName = "SwiftExampleTests"
-               ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -60,13 +50,6 @@
             ReferencedContainer = "container:ZipArchiveExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "${DEBUG_ACTIVITY_MODE}"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
GitHub Actions only supports macOS 12+ now:
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

Also modernising the iOS/tvOS/visionOS/watchOS schemes because Apple requires modern Xcode anyway for those: https://developer.apple.com/ios/submit/

I'm leaving the Carthage scheme untouched, as I don't maintain it.