### PR TITLE
Modernising iOS/tvOS/visionOS/watchOS schemes

### DIFF
--- a/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-iOS.xcscheme
+++ b/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -40,15 +39,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B423AE191C0DF76A0004A2F1"
-            BuildableName = "ZipArchive.framework"
-            BlueprintName = "ZipArchive-iOS"
-            ReferencedContainer = "container:ZipArchive.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-tvos.xcscheme
+++ b/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-tvos.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -40,15 +39,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "37952C251F63B50D00DD6677"
-            BuildableName = "ZipArchive.framework"
-            BlueprintName = "ZipArchive-tvos"
-            ReferencedContainer = "container:ZipArchive.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-visionos.xcscheme
+++ b/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-visionos.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      buildArchitectures = "Automatic">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -16,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C8DEE3642BE59172005150F4"
-               BuildableName = "ZipArchive-visionos.framework"
+               BuildableName = "ZipArchive.framework"
                BlueprintName = "ZipArchive-visionos"
                ReferencedContainer = "container:ZipArchive.xcodeproj">
             </BuildableReference>
@@ -51,7 +50,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C8DEE3642BE59172005150F4"
-            BuildableName = "ZipArchive-visionos.framework"
+            BuildableName = "ZipArchive.framework"
             BlueprintName = "ZipArchive-visionos"
             ReferencedContainer = "container:ZipArchive.xcodeproj">
          </BuildableReference>

--- a/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-watchos.xcscheme
+++ b/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-watchos.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -40,15 +39,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "37952C5D1F63BB7100DD6677"
-            BuildableName = "ZipArchive.framework"
-            BlueprintName = "ZipArchive-watchos"
-            ReferencedContainer = "container:ZipArchive.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Modernising the iOS/tvOS/visionOS/watchOS schemes because Apple requires modern Xcode anyway for those: https://developer.apple.com/ios/submit/

I'm leaving the macOS scheme untouched, for older Xcodes.