### PR TITLE
fix zip64 logic based on missing uncompressed_size

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -103,11 +103,12 @@ typedef NS_ENUM(NSInteger, SSZipArchiveErrorCode) {
 // without password
 + (BOOL)createZipFileAtPath:(NSString *)path withFilesAtPaths:(NSArray<NSString *> *)paths;
 + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath;
-
 + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath keepParentDirectory:(BOOL)keepParentDirectory;
 
-// with optional password, default encryption is AES
-// don't use AES if you need compatibility with native macOS unzip and Archive Utility
+// with optional password
+// - default is AES encryption
+// - don't use AES if you need compatibility with native macOS unzip and Archive Utility
+// - disabling AES will fallback to PKWARE traditional encryption
 + (BOOL)createZipFileAtPath:(NSString *)path withFilesAtPaths:(NSArray<NSString *> *)paths withPassword:(nullable NSString *)password;
 + (BOOL)createZipFileAtPath:(NSString *)path withFilesAtPaths:(NSArray<NSString *> *)paths withPassword:(nullable NSString *)password progressHandler:(void(^ _Nullable)(NSUInteger entryNumber, NSUInteger total))progressHandler;
 + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath withPassword:(nullable NSString *)password;


### PR DESCRIPTION
Fix #619
Fix #626
Fix #693
(Maybe fix #685)
Supersedes #640

Some backstory.
The [legacy minizip](https://github.com/madler/zlib/blob/develop/contrib/minizip/zip.h) had variants up to `zipOpenNewFileInZip4_64`. And minizip-ng is a better drop-in replacement to it.

On 8 October 2017, I added `zipOpenNewFileInZip5` in ZipArchive #393 and in minizip-ng 1.2 https://github.com/zlib-ng/minizip-ng/pull/182 with the extra parameter `int aes` for **optional** aes.

On 9 October 2017, nathan added `zipOpenNewFileInZip5` in minizip-ng 2.0.0 in:
https://github.com/zlib-ng/minizip-ng/commit/8db28c9afef013c426f76b3109b8ba94c51f359f, but with the same signature as `zipOpenNewFileInZip4_64` instead of the required signature I had created a day before. :(

Since then, we kept in ZipArchive a custom version of zip.{h,c} or compat.{h,c} to re-add the `int aes` parameter.

But anyway, the legacy minizip doesn't support AES nor optional AES. So there is no point to keep using the _broken_ compatibility layer.

### First change
So, step one, I re-inject my implementation of `zipOpenNewFileInZip5` directly into ZipArchive's `_zipOpenEntry`. We now use the minizip-ng api `mz_zip_entry_write_open` directly. This allows ZipArchive to keep optional AES support without having to re-modify zip.c or compat.c with each minizip-ng update.

### Second change
Now, into the actual zip64 fix: we don't really want it forced for all files. For compatibility purposes with various clients (like Microsoft Word), we only want to use zip64 when strictly necessary, which means when files are larger than 2 GB.
We could do it two different ways:
- Solution 1, the legacy way, we look if the file is more or less than 2 GB, and we use `MZ_ZIP64_FORCE` or `MZ_ZIP64_DISABLE`. That supposes fetching the actual file size before calling `mz_zip_entry_write_open`.
- Solution 2, we use `MZ_ZIP64_AUTO` and we set `uncompressed_size`. That also supposes fetching the actual file size before calling `mz_zip_entry_write_open`. But that saves us complex logic to account for (`mz_zip_entry_needs_zip64` is forty lines long). So that's the adopted solution. And to adopt this solution, the first change was necessary, because `zipOpenNewFileInZip5` doesn't have any parameter for `uncompressed_size`.
