### PR TITLE
Updating to minizip-ng 4.0.9

### DIFF
--- a/Example/ObjectiveCExampleTests/SSZipArchiveTests.m
+++ b/Example/ObjectiveCExampleTests/SSZipArchiveTests.m
@@ -733,10 +733,14 @@ int twentyMB = 20 * 1024 * 1024;
 - (void)testPathSanitation {
     NSDictionary<NSString *, NSString *> *tests =
     @{
+      // directory path starting with slash
+      @"/a/": @"/a/",
+      // directory path not starting with slash
+      @"a/": @"a/",
       // path traversal
       @"../../../../../../../../../../../tmp/test.txt": @"tmp/test.txt",
       // path traversal, Windows style
-      @"..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\tmp\\test.txt": @"tmp/test.txt",
+      @"..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\tmp\\test.txt": @"..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\tmp\\test.txt",
       // relative path
       @"a/b/../c.txt": @"a/c.txt",
       // path traversal with slash (#680)
@@ -755,8 +759,7 @@ int twentyMB = 20 * 1024 * 1024;
       @"file:a/../../../usr/bin": @"usr/bin",
       };
     for (NSString *str in tests) {
-        //NSLog(@"%@", str);
-        XCTAssertTrue([tests[str] isEqualToString:[str _sanitizedPath]], @"Path should be sanitized for traversal");
+        XCTAssertTrue([tests[str] isEqualToString:[str _sanitizedPath]], @"Path should be sanitized for traversal: %@", str);
     }
 }
 

--- a/SSZipArchive/minizip/compat/ioapi.c
+++ b/SSZipArchive/minizip/compat/ioapi.c
@@ -211,8 +211,7 @@ void mz_stream_ioapi_delete(void **stream) {
     if (!stream)
         return;
     ioapi = (mz_stream_ioapi *)*stream;
-    if (ioapi)
-        free(ioapi);
+    free(ioapi);
     *stream = NULL;
 }
 

--- a/SSZipArchive/minizip/compat/unzip.h
+++ b/SSZipArchive/minizip/compat/unzip.h
@@ -53,7 +53,7 @@ typedef void *unzFile;
 
 #define UNZ_OK                  (0)
 #define UNZ_END_OF_LIST_OF_FILE (-100)
-#define UNZ_ERRNO               (Z_ERRNO)
+#define UNZ_ERRNO               (-1)  /* Z_ERRNO */
 #define UNZ_EOF                 (0)
 #define UNZ_PARAMERROR          (-102)
 #define UNZ_BADZIPFILE          (-103)

--- a/SSZipArchive/minizip/compat/zip.h
+++ b/SSZipArchive/minizip/compat/zip.h
@@ -51,7 +51,7 @@ typedef void *zipFile;
 
 #define ZIP_OK            (0)
 #define ZIP_EOF           (0)
-#define ZIP_ERRNO         (Z_ERRNO)
+#define ZIP_ERRNO         (-1)  /* Z_ERRNO */
 #define ZIP_PARAMERROR    (-102)
 #define ZIP_BADZIPFILE    (-103)
 #define ZIP_INTERNALERROR (-104)

--- a/SSZipArchive/minizip/mz.h
+++ b/SSZipArchive/minizip/mz.h
@@ -14,143 +14,142 @@
 /***************************************************************************/
 
 /* MZ_VERSION */
-#define MZ_VERSION                      ("4.0.7")
-#define MZ_VERSION_BUILD                (0x040007)
+#define MZ_VERSION       ("4.0.9")
+#define MZ_VERSION_BUILD (0x040009)
 
 /* MZ_ERROR */
-#define MZ_OK                           (0)  /* zlib */
-#define MZ_STREAM_ERROR                 (-1) /* zlib */
-#define MZ_DATA_ERROR                   (-3) /* zlib */
-#define MZ_MEM_ERROR                    (-4) /* zlib */
-#define MZ_BUF_ERROR                    (-5) /* zlib */
-#define MZ_VERSION_ERROR                (-6) /* zlib */
+#define MZ_OK             (0)  /* zlib */
+#define MZ_STREAM_ERROR   (-1) /* zlib */
+#define MZ_DATA_ERROR     (-3) /* zlib */
+#define MZ_MEM_ERROR      (-4) /* zlib */
+#define MZ_BUF_ERROR      (-5) /* zlib */
+#define MZ_VERSION_ERROR  (-6) /* zlib */
 
-#define MZ_END_OF_LIST                  (-100)
-#define MZ_END_OF_STREAM                (-101)
+#define MZ_END_OF_LIST    (-100)
+#define MZ_END_OF_STREAM  (-101)
 
-#define MZ_PARAM_ERROR                  (-102)
-#define MZ_FORMAT_ERROR                 (-103)
-#define MZ_INTERNAL_ERROR               (-104)
-#define MZ_CRC_ERROR                    (-105)
-#define MZ_CRYPT_ERROR                  (-106)
-#define MZ_EXIST_ERROR                  (-107)
-#define MZ_PASSWORD_ERROR               (-108)
-#define MZ_SUPPORT_ERROR                (-109)
-#define MZ_HASH_ERROR                   (-110)
-#define MZ_OPEN_ERROR                   (-111)
-#define MZ_CLOSE_ERROR                  (-112)
-#define MZ_SEEK_ERROR                   (-113)
-#define MZ_TELL_ERROR                   (-114)
-#define MZ_READ_ERROR                   (-115)
-#define MZ_WRITE_ERROR                  (-116)
-#define MZ_SIGN_ERROR                   (-117)
-#define MZ_SYMLINK_ERROR                (-118)
+#define MZ_PARAM_ERROR    (-102)
+#define MZ_FORMAT_ERROR   (-103)
+#define MZ_INTERNAL_ERROR (-104)
+#define MZ_CRC_ERROR      (-105)
+#define MZ_CRYPT_ERROR    (-106)
+#define MZ_EXIST_ERROR    (-107)
+#define MZ_PASSWORD_ERROR (-108)
+#define MZ_SUPPORT_ERROR  (-109)
+#define MZ_HASH_ERROR     (-110)
+#define MZ_OPEN_ERROR     (-111)
+#define MZ_CLOSE_ERROR    (-112)
+#define MZ_SEEK_ERROR     (-113)
+#define MZ_TELL_ERROR     (-114)
+#define MZ_READ_ERROR     (-115)
+#define MZ_WRITE_ERROR    (-116)
+#define MZ_SIGN_ERROR     (-117)
+#define MZ_SYMLINK_ERROR  (-118)
 
 /* MZ_OPEN */
-#define MZ_OPEN_MODE_READ               (0x01)
-#define MZ_OPEN_MODE_WRITE              (0x02)
-#define MZ_OPEN_MODE_READWRITE          (MZ_OPEN_MODE_READ | MZ_OPEN_MODE_WRITE)
-#define MZ_OPEN_MODE_APPEND             (0x04)
-#define MZ_OPEN_MODE_CREATE             (0x08)
-#define MZ_OPEN_MODE_EXISTING           (0x10)
+#define MZ_OPEN_MODE_READ      (0x01)
+#define MZ_OPEN_MODE_WRITE     (0x02)
+#define MZ_OPEN_MODE_READWRITE (MZ_OPEN_MODE_READ | MZ_OPEN_MODE_WRITE)
+#define MZ_OPEN_MODE_APPEND    (0x04)
+#define MZ_OPEN_MODE_CREATE    (0x08)
+#define MZ_OPEN_MODE_EXISTING  (0x10)
 
 /* MZ_SEEK */
-#define MZ_SEEK_SET                     (0)
-#define MZ_SEEK_CUR                     (1)
-#define MZ_SEEK_END                     (2)
+#define MZ_SEEK_SET (0)
+#define MZ_SEEK_CUR (1)
+#define MZ_SEEK_END (2)
 
 /* MZ_COMPRESS */
-#define MZ_COMPRESS_METHOD_STORE        (0)
-#define MZ_COMPRESS_METHOD_DEFLATE      (8)
-#define MZ_COMPRESS_METHOD_BZIP2        (12)
-#define MZ_COMPRESS_METHOD_LZMA         (14)
-#define MZ_COMPRESS_METHOD_ZSTD         (93)
-#define MZ_COMPRESS_METHOD_XZ           (95)
-#define MZ_COMPRESS_METHOD_AES          (99)
+#define MZ_COMPRESS_METHOD_STORE   (0)
+#define MZ_COMPRESS_METHOD_DEFLATE (8)
+#define MZ_COMPRESS_METHOD_BZIP2   (12)
+#define MZ_COMPRESS_METHOD_LZMA    (14)
+#define MZ_COMPRESS_METHOD_ZSTD    (93)
+#define MZ_COMPRESS_METHOD_XZ      (95)
+#define MZ_COMPRESS_METHOD_AES     (99)
 
-#define MZ_COMPRESS_LEVEL_DEFAULT       (-1)
-#define MZ_COMPRESS_LEVEL_FAST          (2)
-#define MZ_COMPRESS_LEVEL_NORMAL        (6)
-#define MZ_COMPRESS_LEVEL_BEST          (9)
+#define MZ_COMPRESS_LEVEL_DEFAULT  (-1)
+#define MZ_COMPRESS_LEVEL_FAST     (2)
+#define MZ_COMPRESS_LEVEL_NORMAL   (6)
+#define MZ_COMPRESS_LEVEL_BEST     (9)
 
 /* MZ_ZIP_FLAG */
-#define MZ_ZIP_FLAG_ENCRYPTED           (1 << 0)
-#define MZ_ZIP_FLAG_LZMA_EOS_MARKER     (1 << 1)
-#define MZ_ZIP_FLAG_DEFLATE_MAX         (1 << 1)
-#define MZ_ZIP_FLAG_DEFLATE_NORMAL      (0)
-#define MZ_ZIP_FLAG_DEFLATE_FAST        (1 << 2)
-#define MZ_ZIP_FLAG_DEFLATE_SUPER_FAST  (MZ_ZIP_FLAG_DEFLATE_FAST | \
-                                         MZ_ZIP_FLAG_DEFLATE_MAX)
-#define MZ_ZIP_FLAG_DATA_DESCRIPTOR     (1 << 3)
-#define MZ_ZIP_FLAG_UTF8                (1 << 11)
-#define MZ_ZIP_FLAG_MASK_LOCAL_INFO     (1 << 13)
+#define MZ_ZIP_FLAG_ENCRYPTED          (1 << 0)
+#define MZ_ZIP_FLAG_LZMA_EOS_MARKER    (1 << 1)
+#define MZ_ZIP_FLAG_DEFLATE_MAX        (1 << 1)
+#define MZ_ZIP_FLAG_DEFLATE_NORMAL     (0)
+#define MZ_ZIP_FLAG_DEFLATE_FAST       (1 << 2)
+#define MZ_ZIP_FLAG_DEFLATE_SUPER_FAST (MZ_ZIP_FLAG_DEFLATE_FAST | MZ_ZIP_FLAG_DEFLATE_MAX)
+#define MZ_ZIP_FLAG_DATA_DESCRIPTOR    (1 << 3)
+#define MZ_ZIP_FLAG_UTF8               (1 << 11)
+#define MZ_ZIP_FLAG_MASK_LOCAL_INFO    (1 << 13)
 
 /* MZ_ZIP_EXTENSION */
-#define MZ_ZIP_EXTENSION_ZIP64          (0x0001)
-#define MZ_ZIP_EXTENSION_NTFS           (0x000a)
-#define MZ_ZIP_EXTENSION_AES            (0x9901)
-#define MZ_ZIP_EXTENSION_UNIX1          (0x000d)
-#define MZ_ZIP_EXTENSION_SIGN           (0x10c5)
-#define MZ_ZIP_EXTENSION_HASH           (0x1a51)
-#define MZ_ZIP_EXTENSION_CDCD           (0xcdcd)
+#define MZ_ZIP_EXTENSION_ZIP64 (0x0001)
+#define MZ_ZIP_EXTENSION_NTFS  (0x000a)
+#define MZ_ZIP_EXTENSION_AES   (0x9901)
+#define MZ_ZIP_EXTENSION_UNIX1 (0x000d)
+#define MZ_ZIP_EXTENSION_SIGN  (0x10c5)
+#define MZ_ZIP_EXTENSION_HASH  (0x1a51)
+#define MZ_ZIP_EXTENSION_CDCD  (0xcdcd)
 
 /* MZ_ZIP64 */
-#define MZ_ZIP64_AUTO                   (0)
-#define MZ_ZIP64_FORCE                  (1)
-#define MZ_ZIP64_DISABLE                (2)
+#define MZ_ZIP64_AUTO    (0)
+#define MZ_ZIP64_FORCE   (1)
+#define MZ_ZIP64_DISABLE (2)
 
 /* MZ_HOST_SYSTEM */
-#define MZ_HOST_SYSTEM(VERSION_MADEBY)  ((uint8_t)(VERSION_MADEBY >> 8))
-#define MZ_HOST_SYSTEM_MSDOS            (0)
-#define MZ_HOST_SYSTEM_UNIX             (3)
-#define MZ_HOST_SYSTEM_WINDOWS_NTFS     (10)
-#define MZ_HOST_SYSTEM_RISCOS           (13)
-#define MZ_HOST_SYSTEM_OSX_DARWIN       (19)
+#define MZ_HOST_SYSTEM(VERSION_MADEBY) ((uint8_t)(VERSION_MADEBY >> 8))
+#define MZ_HOST_SYSTEM_MSDOS           (0)
+#define MZ_HOST_SYSTEM_UNIX            (3)
+#define MZ_HOST_SYSTEM_WINDOWS_NTFS    (10)
+#define MZ_HOST_SYSTEM_RISCOS          (13)
+#define MZ_HOST_SYSTEM_OSX_DARWIN      (19)
 
 /* MZ_PKCRYPT */
-#define MZ_PKCRYPT_HEADER_SIZE          (12)
+#define MZ_PKCRYPT_HEADER_SIZE (12)
 
 /* MZ_AES */
-#define MZ_AES_VERSION                  (1)
-#define MZ_AES_MODE_ECB                 (0)
-#define MZ_AES_MODE_CBC                 (1)
-#define MZ_AES_MODE_GCM                 (2)
-#define MZ_AES_STRENGTH_128             (1)
-#define MZ_AES_STRENGTH_192             (2)
-#define MZ_AES_STRENGTH_256             (3)
-#define MZ_AES_KEY_LENGTH_MAX           (32)
-#define MZ_AES_BLOCK_SIZE               (16)
-#define MZ_AES_FOOTER_SIZE              (10)
+#define MZ_AES_VERSION        (1)
+#define MZ_AES_MODE_ECB       (0)
+#define MZ_AES_MODE_CBC       (1)
+#define MZ_AES_MODE_GCM       (2)
+#define MZ_AES_STRENGTH_128   (1)
+#define MZ_AES_STRENGTH_192   (2)
+#define MZ_AES_STRENGTH_256   (3)
+#define MZ_AES_KEY_LENGTH_MAX (32)
+#define MZ_AES_BLOCK_SIZE     (16)
+#define MZ_AES_FOOTER_SIZE    (10)
 
 /* MZ_HASH */
-#define MZ_HASH_MD5                     (10)
-#define MZ_HASH_MD5_SIZE                (16)
-#define MZ_HASH_SHA1                    (20)
-#define MZ_HASH_SHA1_SIZE               (20)
-#define MZ_HASH_SHA224                  (22)
-#define MZ_HASH_SHA224_SIZE             (28)
-#define MZ_HASH_SHA256                  (23)
-#define MZ_HASH_SHA256_SIZE             (32)
-#define MZ_HASH_SHA384                  (24)
-#define MZ_HASH_SHA384_SIZE             (48)
-#define MZ_HASH_SHA512                  (25)
-#define MZ_HASH_SHA512_SIZE             (64)
-#define MZ_HASH_MAX_SIZE                (256)
+#define MZ_HASH_MD5         (10)
+#define MZ_HASH_MD5_SIZE    (16)
+#define MZ_HASH_SHA1        (20)
+#define MZ_HASH_SHA1_SIZE   (20)
+#define MZ_HASH_SHA224      (22)
+#define MZ_HASH_SHA224_SIZE (28)
+#define MZ_HASH_SHA256      (23)
+#define MZ_HASH_SHA256_SIZE (32)
+#define MZ_HASH_SHA384      (24)
+#define MZ_HASH_SHA384_SIZE (48)
+#define MZ_HASH_SHA512      (25)
+#define MZ_HASH_SHA512_SIZE (64)
+#define MZ_HASH_MAX_SIZE    (256)
 
 /* MZ_ENCODING */
-#define MZ_ENCODING_CODEPAGE_437        (437)
-#define MZ_ENCODING_CODEPAGE_932        (932)
-#define MZ_ENCODING_CODEPAGE_936        (936)
-#define MZ_ENCODING_CODEPAGE_950        (950)
-#define MZ_ENCODING_UTF8                (65001)
+#define MZ_ENCODING_CODEPAGE_437 (437)
+#define MZ_ENCODING_CODEPAGE_932 (932)
+#define MZ_ENCODING_CODEPAGE_936 (936)
+#define MZ_ENCODING_CODEPAGE_950 (950)
+#define MZ_ENCODING_UTF8         (65001)
 
 /* MZ_UTILITY */
-#define MZ_UNUSED(SYMBOL)               ((void)SYMBOL)
+#define MZ_UNUSED(SYMBOL) ((void)SYMBOL)
 
 #if defined(_WIN32) && defined(MZ_EXPORTS)
-#define MZ_EXPORT __declspec(dllexport)
+#  define MZ_EXPORT __declspec(dllexport)
 #else
-#define MZ_EXPORT
+#  define MZ_EXPORT
 #endif
 
 /***************************************************************************/

--- a/SSZipArchive/minizip/mz_os.h
+++ b/SSZipArchive/minizip/mz_os.h
@@ -150,6 +150,9 @@ struct dirent *mz_os_read_dir(DIR *dir);
 int32_t mz_os_close_dir(DIR *dir);
 /* Closes a directory that has been opened for listing */
 
+int32_t mz_os_is_dir_separator(const char c);
+/* Checks to see if character is a directory separator */
+
 int32_t mz_os_is_dir(const char *path);
 /* Checks to see if path is a directory */
 

--- a/SSZipArchive/minizip/mz_os_posix.c
+++ b/SSZipArchive/minizip/mz_os_posix.c
@@ -37,6 +37,10 @@
 #  include <stdlib.h> /* arc4random_buf */
 #endif
 
+#ifndef MZ_PRESERVE_NATIVE_STRUCTURE
+#  define MZ_PRESERVE_NATIVE_STRUCTURE 1
+#endif
+
 /***************************************************************************/
 
 #if defined(HAVE_ICONV)
@@ -287,6 +291,18 @@ int32_t mz_os_close_dir(DIR *dir) {
     if (closedir(dir) == -1)
         return MZ_INTERNAL_ERROR;
     return MZ_OK;
+}
+
+int32_t mz_os_is_dir_separator(const char c) {
+#if MZ_PRESERVE_NATIVE_STRUCTURE
+    // While not strictly adhering to 4.4.17.1,
+    // this preserves UNIX filesystem structure.
+    return c == '/';
+#else
+    // While strictly adhering to 4.4.17.1,
+    // this corrupts UNIX filesystem structure (a filename with a '\\' will become a folder + a file).
+    return c == '\\' || c == '/';
+#endif
 }
 
 int32_t mz_os_is_dir(const char *path) {

--- a/SSZipArchive/minizip/mz_strm.c
+++ b/SSZipArchive/minizip/mz_strm.c
@@ -537,7 +537,6 @@ void mz_stream_raw_delete(void **stream) {
     if (!stream)
         return;
     raw = (mz_stream_raw *)*stream;
-    if (raw)
-        free(raw);
+    free(raw);
     *stream = NULL;
 }

--- a/SSZipArchive/minizip/mz_strm_buf.c
+++ b/SSZipArchive/minizip/mz_strm_buf.c
@@ -372,8 +372,7 @@ void mz_stream_buffered_delete(void **stream) {
     if (!stream)
         return;
     buffered = (mz_stream_buffered *)*stream;
-    if (buffered)
-        free(buffered);
+    free(buffered);
     *stream = NULL;
 }
 

--- a/SSZipArchive/minizip/mz_strm_os_posix.c
+++ b/SSZipArchive/minizip/mz_strm_os_posix.c
@@ -186,8 +186,7 @@ void mz_stream_os_delete(void **stream) {
     if (!stream)
         return;
     posix = (mz_stream_posix *)*stream;
-    if (posix)
-        free(posix);
+    free(posix);
     *stream = NULL;
 }
 

--- a/SSZipArchive/minizip/mz_strm_pkcrypt.c
+++ b/SSZipArchive/minizip/mz_strm_pkcrypt.c
@@ -315,8 +315,7 @@ void mz_stream_pkcrypt_delete(void **stream) {
     if (!stream)
         return;
     pkcrypt = (mz_stream_pkcrypt *)*stream;
-    if (pkcrypt)
-        free(pkcrypt);
+    free(pkcrypt);
     *stream = NULL;
 }
 

--- a/SSZipArchive/minizip/mz_strm_split.c
+++ b/SSZipArchive/minizip/mz_strm_split.c
@@ -35,19 +35,19 @@ static mz_stream_vtbl mz_stream_split_vtbl = {
 
 typedef struct mz_stream_split_s {
     mz_stream stream;
-    int32_t is_open;
     int64_t disk_size;
     int64_t total_in;
     int64_t total_in_disk;
     int64_t total_out;
     int64_t total_out_disk;
+    int32_t is_open;
     int32_t mode;
     char *path_cd;
     char *path_disk;
     uint32_t path_disk_size;
     int32_t number_disk;
-    int32_t current_disk;
     int64_t current_disk_size;
+    int32_t current_disk;
     int32_t reached_end;
 } mz_stream_split;
 
@@ -404,11 +404,8 @@ void mz_stream_split_delete(void **stream) {
         return;
     split = (mz_stream_split *)*stream;
     if (split) {
-        if (split->path_cd)
-            free(split->path_cd);
-        if (split->path_disk)
-            free(split->path_disk);
-
+        free(split->path_cd);
+        free(split->path_disk);
         free(split);
     }
     *stream = NULL;

--- a/SSZipArchive/minizip/mz_strm_zlib.c
+++ b/SSZipArchive/minizip/mz_strm_zlib.c
@@ -369,8 +369,7 @@ void mz_stream_zlib_delete(void **stream) {
     if (!stream)
         return;
     zlib = (mz_stream_zlib *)*stream;
-    if (zlib)
-        free(zlib);
+    free(zlib);
     *stream = NULL;
 }
 

--- a/SSZipArchive/minizip/mz_zip.c
+++ b/SSZipArchive/minizip/mz_zip.c
@@ -17,6 +17,7 @@
 
 #include "mz.h"
 #include "mz_crypt.h"
+#include "mz_os.h"
 #include "mz_strm.h"
 #ifdef HAVE_BZIP2
 #  include "mz_strm_bzip.h"
@@ -2294,8 +2295,7 @@ int32_t mz_zip_entry_is_dir(void *handle) {
 
     filename_length = (int32_t)strlen(zip->file_info.filename);
     if (filename_length > 0) {
-        if ((zip->file_info.filename[filename_length - 1] == '/') ||
-            (zip->file_info.filename[filename_length - 1] == '\\'))
+        if (mz_os_is_dir_separator(zip->file_info.filename[filename_length - 1]))
             return MZ_OK;
     }
     return MZ_EXIST_ERROR;

--- a/SSZipArchive/minizip/mz_zip.c
+++ b/SSZipArchive/minizip/mz_zip.c
@@ -56,15 +56,15 @@
 /***************************************************************************/
 
 #define MZ_ZIP_MAGIC_LOCALHEADER        (0x04034b50)
-#define MZ_ZIP_MAGIC_LOCALHEADERU8      { 0x50, 0x4b, 0x03, 0x04 }
+#define MZ_ZIP_MAGIC_LOCALHEADERU8      {0x50, 0x4b, 0x03, 0x04}
 #define MZ_ZIP_MAGIC_CENTRALHEADER      (0x02014b50)
-#define MZ_ZIP_MAGIC_CENTRALHEADERU8    { 0x50, 0x4b, 0x01, 0x02 }
+#define MZ_ZIP_MAGIC_CENTRALHEADERU8    {0x50, 0x4b, 0x01, 0x02}
 #define MZ_ZIP_MAGIC_ENDHEADER          (0x06054b50)
-#define MZ_ZIP_MAGIC_ENDHEADERU8        { 0x50, 0x4b, 0x05, 0x06 }
+#define MZ_ZIP_MAGIC_ENDHEADERU8        {0x50, 0x4b, 0x05, 0x06}
 #define MZ_ZIP_MAGIC_ENDHEADER64        (0x06064b50)
 #define MZ_ZIP_MAGIC_ENDLOCHEADER64     (0x07064b50)
 #define MZ_ZIP_MAGIC_DATADESCRIPTOR     (0x08074b50)
-#define MZ_ZIP_MAGIC_DATADESCRIPTORU8   { 0x50, 0x4b, 0x07, 0x08 }
+#define MZ_ZIP_MAGIC_DATADESCRIPTORU8   {0x50, 0x4b, 0x07, 0x08}
 
 #define MZ_ZIP_SIZE_LD_ITEM             (30)
 #define MZ_ZIP_SIZE_CD_ITEM             (46)
@@ -75,7 +75,7 @@
 #define MZ_ZIP_UNCOMPR_SIZE64_CUSHION   (2 * 1024 * 1024)
 
 #ifndef MZ_ZIP_EOCD_MAX_BACK
-#define MZ_ZIP_EOCD_MAX_BACK            (1 << 20)
+#  define MZ_ZIP_EOCD_MAX_BACK (1 << 20)
 #endif
 
 /***************************************************************************/
@@ -84,36 +84,36 @@ typedef struct mz_zip_s {
     mz_zip_file file_info;
     mz_zip_file local_file_info;
 
-    void *stream;                   /* main stream */
-    void *cd_stream;                /* pointer to the stream with the cd */
-    void *cd_mem_stream;            /* memory stream for central directory */
-    void *compress_stream;          /* compression stream */
-    void *crypt_stream;             /* encryption stream */
-    void *file_info_stream;         /* memory stream for storing file info */
-    void *local_file_info_stream;   /* memory stream for storing local file info */
+    void *stream;                 /* main stream */
+    void *cd_stream;              /* pointer to the stream with the cd */
+    void *cd_mem_stream;          /* memory stream for central directory */
+    void *compress_stream;        /* compression stream */
+    void *crypt_stream;           /* encryption stream */
+    void *file_info_stream;       /* memory stream for storing file info */
+    void *local_file_info_stream; /* memory stream for storing local file info */
 
-    int32_t  open_mode;
-    uint8_t  recover;
-    uint8_t  data_descriptor;
+    int32_t open_mode;
+    uint8_t recover;
+    uint8_t data_descriptor;
 
-    uint32_t disk_number_with_cd;   /* number of the disk with the central dir */
-    int64_t  disk_offset_shift;     /* correction for zips that have wrong offset start of cd */
+    uint32_t disk_number_with_cd; /* number of the disk with the central dir */
+    int64_t disk_offset_shift;    /* correction for zips that have wrong offset start of cd */
 
-    int64_t  cd_start_pos;          /* pos of the first file in the central dir stream */
-    int64_t  cd_current_pos;        /* pos of the current file in the central dir */
-    int64_t  cd_offset;             /* offset of start of central directory */
-    int64_t  cd_size;               /* size of the central directory */
-    uint32_t cd_signature;          /* signature of central directory */
+    int64_t cd_start_pos;   /* pos of the first file in the central dir stream */
+    int64_t cd_current_pos; /* pos of the current file in the central dir */
+    int64_t cd_offset;      /* offset of start of central directory */
+    int64_t cd_size;        /* size of the central directory */
+    uint32_t cd_signature;  /* signature of central directory */
 
-    uint8_t  entry_scanned;         /* entry header information read ok */
-    uint8_t  entry_opened;          /* entry is open for read/write */
-    uint8_t  entry_raw;             /* entry opened with raw mode */
-    uint32_t entry_crc32;           /* entry crc32  */
+    uint8_t entry_scanned; /* entry header information read ok */
+    uint8_t entry_opened;  /* entry is open for read/write */
+    uint8_t entry_raw;     /* entry opened with raw mode */
+    uint32_t entry_crc32;  /* entry crc32  */
 
     uint64_t number_entry;
 
     uint16_t version_madeby;
-    char     *comment;
+    char *comment;
 } mz_zip;
 
 /***************************************************************************/
@@ -188,8 +188,7 @@ static int32_t mz_zip_search_zip64_eocd(void *stream, const int64_t end_central_
 
 #ifdef HAVE_PKCRYPT
 /* Get PKWARE traditional encryption verifier */
-static uint16_t mz_zip_get_pk_verify(uint32_t dos_date, uint64_t crc, uint16_t flag)
-{
+static uint16_t mz_zip_get_pk_verify(uint32_t dos_date, uint64_t crc, uint16_t flag) {
     /* Info-ZIP modification to ZipCrypto format: if bit 3 of the general
      * purpose bit flag is set, it uses high byte of 16-bit File Time. */
     if (flag & MZ_ZIP_FLAG_DATA_DESCRIPTOR)
@@ -787,9 +786,10 @@ static int32_t mz_zip_entry_write_header(void *stream, uint8_t local, mz_zip_fil
     }
 
     if (err == MZ_OK) {
-        const char *backslash = NULL;
         const char *next = filename;
         int32_t left = filename_length;
+#if defined(_WIN32)
+        const char *backslash = NULL;
 
         /* Ensure all slashes are written as forward slashes according to 4.4.17.1 */
         while ((err == MZ_OK) && (backslash = strchr(next, '\\'))) {
@@ -801,7 +801,7 @@ static int32_t mz_zip_entry_write_header(void *stream, uint8_t local, mz_zip_fil
             left -= part_length + 1;
             next = backslash + 1;
         }
-
+#endif
         if (err == MZ_OK && left > 0) {
             if (mz_stream_write(stream, next, left) != left)
                 err = MZ_WRITE_ERROR;
@@ -1325,16 +1325,17 @@ static int32_t mz_zip_recover_cd(void *handle) {
             }
 
             if (local_file_info.flag & MZ_ZIP_FLAG_DATA_DESCRIPTOR || local_file_info.compressed_size == 0) {
-                /* Search backwards for the descriptor, seeking too far back will be incorrect if compressed size is small */
+                /* Search backwards for the descriptor, seeking too far back will be incorrect if compressed size is
+                 * small */
                 err = mz_stream_find_reverse(zip->stream, (const void *)descriptor_magic, sizeof(descriptor_magic),
-                            MZ_ZIP_SIZE_MAX_DATA_DESCRIPTOR, &descriptor_pos);
+                                             MZ_ZIP_SIZE_MAX_DATA_DESCRIPTOR, &descriptor_pos);
                 if (err == MZ_OK) {
-                    if (mz_zip_extrafield_contains(local_file_info.extrafield,
-                        local_file_info.extrafield_size, MZ_ZIP_EXTENSION_ZIP64, NULL) == MZ_OK)
+                    if (mz_zip_extrafield_contains(local_file_info.extrafield, local_file_info.extrafield_size,
+                                                   MZ_ZIP_EXTENSION_ZIP64, NULL) == MZ_OK)
                         zip64 = 1;
 
-                    err = mz_zip_entry_read_descriptor(zip->stream, zip64, &crc32,
-                        &compressed_size, &uncompressed_size);
+                    err =
+                        mz_zip_entry_read_descriptor(zip->stream, zip64, &crc32, &compressed_size, &uncompressed_size);
 
                     if (err == MZ_OK) {
                         if (local_file_info.crc == 0)
@@ -1415,9 +1416,7 @@ void mz_zip_delete(void **handle) {
     if (!handle)
         return;
     zip = (mz_zip *)*handle;
-    if (zip) {
-        free(zip);
-    }
+    free(zip);
     *handle = NULL;
 }
 
@@ -1559,8 +1558,7 @@ int32_t mz_zip_set_comment(void *handle, const char *comment) {
     int32_t comment_size = 0;
     if (!zip || !comment)
         return MZ_PARAM_ERROR;
-    if (zip->comment)
-        free(zip->comment);
+    free(zip->comment);
     comment_size = (int32_t)strlen(comment);
     if (comment_size > UINT16_MAX)
         return MZ_PARAM_ERROR;
@@ -2736,7 +2734,8 @@ uint32_t mz_zip_tm_to_dosdate(const struct tm *ptm) {
     if (mz_zip_invalid_date(&fixed_tm))
         return 0;
 
-    return (((uint32_t)fixed_tm.tm_mday + (32 * ((uint32_t)fixed_tm.tm_mon + 1)) + (512 * (uint32_t)fixed_tm.tm_year)) << 16) |
+    return (((uint32_t)fixed_tm.tm_mday + (32 * ((uint32_t)fixed_tm.tm_mon + 1)) + (512 * (uint32_t)fixed_tm.tm_year))
+            << 16) |
         (((uint32_t)fixed_tm.tm_sec / 2) + (32 * (uint32_t)fixed_tm.tm_min) + (2048 * (uint32_t)fixed_tm.tm_hour));
 }
 

--- a/SSZipArchive/minizip/mz_zip_rw.c
+++ b/SSZipArchive/minizip/mz_zip_rw.c
@@ -1659,7 +1659,7 @@ int32_t mz_zip_writer_add_path(void *handle, const char *path, const char *root_
     char full_path[1024];
     char path_dir[1024];
 
-    if (strrchr(path, '*')) {
+    if (strrchr(path, '*') && mz_os_file_exists(path) != MZ_OK) {
         strncpy(path_dir, path, sizeof(path_dir) - 1);
         path_dir[sizeof(path_dir) - 1] = 0;
         mz_path_remove_filename(path_dir);


### PR DESCRIPTION
Updating minizip to 4.0.9.dev (https://github.com/zlib-ng/minizip-ng/pull/867)

Fix #731

Changelog:
- fix: https://github.com/zlib-ng/minizip-ng/pull/834
- fix: https://github.com/zlib-ng/minizip-ng/pull/832
- fix: https://github.com/zlib-ng/minizip-ng/pull/865

In other words:
- It fixes zipping files with `*` in the name. (old bug?)
- It fixes zipping files with `\` in the name. (regression in minizip 3.0.7 -- ZipArchive 2.5.3)
- It fixes unzipping files with `\` in the name. (old bug?)