### PR TITLE
In writeData, set the uncompressed size based on the length of the data [Issue #757]

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -1198,6 +1198,9 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
     mz_zip_file zipInfo = {};
     [SSZipArchive zipInfo:&zipInfo setDate:[NSDate date]];
     
+    // Though we don't have a file, the uncompressed size is just the length of the data
+    zipInfo.uncompressed_size = data.length;
+    
     int error = _zipOpenEntry(_zip, filename, &zipInfo, compressionLevel, password, aes, 1);
     
     zipWriteInFileInZip(_zip, data.bytes, (unsigned int)data.length);


### PR DESCRIPTION
This provides the necessary information to mz_zip_entry_needs_zip64() so that it can correctly determine whether to use zip64.

https://github.com/ZipArchive/ZipArchive/issues/757