### PR TITLE
Use default (readable) file permissions in writeData

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -1182,6 +1182,37 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
     return error == ZIP_OK;
 }
 
+
+// Returns default, readable permissions for a file (e.g. one added with
+// the `writeData` functions below). This mimics the behavior of the UnZip
+// command line utility when unzipping a file with a "non-unix" host, like
+// Darwin, when the `external_fa` is 0.
+// See https://github.com/ZipArchive/ZipArchive/issues/761
+static uint32_t
+defaultExternalFileAttributesForRegularFile(void)
+{
+    // Get the current umask
+    mode_t savedUmask = umask(0);
+    
+    // Restore the umask (we just wanted to read it)
+    umask(savedUmask);
+
+    // Start with rw-rw-rw-
+    mode_t basePermissions = 0666;
+    
+    // Apply the umask, clearing bits according to the mask
+    // This will result in 0644 (rw-r--r--) when umask is 022, as on Darwin
+    mode_t permissions = basePermissions & ~savedUmask;
+
+    // Convert this into an octal by adding the flag for a regular file
+    mode_t st_mode = S_IFREG | permissions;
+
+    // Keep only the POSIX mode bits (the lowest 16 bits) and then shift
+    // since unix file attributes are placed in the high 16 bits of external_fa
+    return ((uint32_t)st_mode & 0xFFFFu) << 16;
+}
+
+
 - (BOOL)writeData:(NSData *)data filename:(nullable NSString *)filename withPassword:(nullable NSString *)password
 {
     return [self writeData:data filename:filename compressionLevel:Z_DEFAULT_COMPRESSION password:password AES:YES];
@@ -1201,6 +1232,10 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
     // Though we don't have a file, the uncompressed size is just the length of the data
     zipInfo.uncompressed_size = data.length;
     
+    // Specify a reasonable value for permissions
+    // See https://github.com/ZipArchive/ZipArchive/issues/761
+    zipInfo.external_fa = defaultExternalFileAttributesForRegularFile();
+
     int error = _zipOpenEntry(_zip, filename, &zipInfo, compressionLevel, password, aes, 1);
     
     zipWriteInFileInZip(_zip, data.bytes, (unsigned int)data.length);

--- a/ZipArchive.xcodeproj/project.pbxproj
+++ b/ZipArchive.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -137,6 +137,7 @@
 		37952C881F63BBD500DD6677 /* SSZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE481C0DF7950004A2F1 /* SSZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		37952C891F63BBDA00DD6677 /* SSZipArchive.m in Sources */ = {isa = PBXBuildFile; fileRef = B423AE491C0DF7950004A2F1 /* SSZipArchive.m */; };
 		37952C8B1F63BBE400DD6677 /* ZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = B423AE4A1C0DF7950004A2F1 /* ZipArchive.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DF786272EE35CDD0043F3A8 /* ZipArchive.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFF75A241C37279600F450AC /* ZipArchive.framework */; };
 		93CE5D5E227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93CE5D5F227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93CE5D60227FE5C50003464F /* SSZipCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 93CE5D5D227FE5C50003464F /* SSZipCommon.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -214,6 +215,16 @@
 		C8DEE38D2BE59172005150F4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 330100222AC89AA8001431B0 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		6DF786282EE35CDD0043F3A8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B423AE111C0DF76A0004A2F1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AFF75A231C37279600F450AC;
+			remoteInfo = "ZipArchive-Mac";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		330100222AC89AA8001431B0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3775F3252276B14100A1840B /* mz_strm_pkcrypt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mz_strm_pkcrypt.c; sourceTree = "<group>"; };
@@ -257,6 +268,7 @@
 		378439CB227AC031000BC165 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS5.2.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
 		37952C261F63B50D00DD6677 /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		37952C5E1F63BB7100DD6677 /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DF786232EE35CDD0043F3A8 /* ZipArchiveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZipArchiveTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		93CE5D5D227FE5C50003464F /* SSZipCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSZipCommon.h; sourceTree = "<group>"; };
 		AFF75A241C37279600F450AC /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B423AE1A1C0DF76A0004A2F1 /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -272,6 +284,10 @@
 		C8BD22DB2CE2B27B00843A77 /* zip.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = zip.c; sourceTree = "<group>"; };
 		C8DEE3912BE59172005150F4 /* ZipArchive.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipArchive.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		6DF786242EE35CDD0043F3A8 /* ZipArchiveTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ZipArchiveTests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		37952C221F63B50D00DD6677 /* Frameworks */ = {
@@ -291,6 +307,14 @@
 				378439CA227AC02B000BC165 /* libiconv.tbd in Frameworks */,
 				378439CC227AC031000BC165 /* libz.tbd in Frameworks */,
 				378439B7227ABD2B000BC165 /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6DF786202EE35CDD0043F3A8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DF786272EE35CDD0043F3A8 /* ZipArchive.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -366,6 +390,7 @@
 			isa = PBXGroup;
 			children = (
 				B423AE251C0DF7950004A2F1 /* SSZipArchive */,
+				6DF786242EE35CDD0043F3A8 /* ZipArchiveTests */,
 				3775F4242276C5C000A1840B /* Frameworks */,
 				B423AE1B1C0DF76A0004A2F1 /* Products */,
 			);
@@ -379,6 +404,7 @@
 				37952C261F63B50D00DD6677 /* ZipArchive.framework */,
 				37952C5E1F63BB7100DD6677 /* ZipArchive.framework */,
 				C8DEE3912BE59172005150F4 /* ZipArchive.framework */,
+				6DF786232EE35CDD0043F3A8 /* ZipArchiveTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -617,6 +643,29 @@
 			productReference = 37952C5E1F63BB7100DD6677 /* ZipArchive.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		6DF786222EE35CDD0043F3A8 /* ZipArchiveTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6DF7862C2EE35CDD0043F3A8 /* Build configuration list for PBXNativeTarget "ZipArchiveTests" */;
+			buildPhases = (
+				6DF7861F2EE35CDD0043F3A8 /* Sources */,
+				6DF786202EE35CDD0043F3A8 /* Frameworks */,
+				6DF786212EE35CDD0043F3A8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6DF786292EE35CDD0043F3A8 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				6DF786242EE35CDD0043F3A8 /* ZipArchiveTests */,
+			);
+			name = ZipArchiveTests;
+			packageProductDependencies = (
+			);
+			productName = ZipArchiveTests;
+			productReference = 6DF786232EE35CDD0043F3A8 /* ZipArchiveTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		AFF75A231C37279600F450AC /* ZipArchive-Mac */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AFF75A291C37279600F450AC /* Build configuration list for PBXNativeTarget "ZipArchive-Mac" */;
@@ -677,7 +726,7 @@
 		B423AE111C0DF76A0004A2F1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0730;
+				LastSwiftUpdateCheck = 2600;
 				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = smumryak;
 				TargetAttributes = {
@@ -686,6 +735,9 @@
 					};
 					37952C5D1F63BB7100DD6677 = {
 						CreatedOnToolsVersion = 8.3.3;
+					};
+					6DF786222EE35CDD0043F3A8 = {
+						CreatedOnToolsVersion = 26.0.1;
 					};
 					AFF75A231C37279600F450AC = {
 						CreatedOnToolsVersion = 7.2;
@@ -714,6 +766,7 @@
 				37952C251F63B50D00DD6677 /* ZipArchive-tvos */,
 				C8DEE3642BE59172005150F4 /* ZipArchive-visionos */,
 				37952C5D1F63BB7100DD6677 /* ZipArchive-watchos */,
+				6DF786222EE35CDD0043F3A8 /* ZipArchiveTests */,
 			);
 		};
 /* End PBXProject section */
@@ -732,6 +785,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				330100262AC89AA8001431B0 /* PrivacyInfo.xcprivacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6DF786212EE35CDD0043F3A8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -812,6 +872,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6DF7861F2EE35CDD0043F3A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AFF75A1F1C37279600F450AC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -889,6 +956,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		6DF786292EE35CDD0043F3A8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AFF75A231C37279600F450AC /* ZipArchive-Mac */;
+			targetProxy = 6DF786282EE35CDD0043F3A8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
 		37952C2B1F63B50D00DD6677 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -905,7 +980,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SSZipArchive/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = appletvos;
@@ -931,7 +1010,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SSZipArchive/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = appletvos;
@@ -957,7 +1040,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SSZipArchive/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = watchos;
@@ -986,13 +1073,87 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SSZipArchive/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 8.4;
+			};
+			name = Release;
+		};
+		6DF7862A2EE35CDD0043F3A8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5KKYLJ96NW;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = co.180g.ZipArchiveTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		6DF7862B2EE35CDD0043F3A8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5KKYLJ96NW;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = co.180g.ZipArchiveTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1010,7 +1171,11 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "$(SRCROOT)/SSZipArchive/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
@@ -1034,7 +1199,11 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "$(SRCROOT)/SSZipArchive/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
@@ -1165,7 +1334,8 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1189,7 +1359,11 @@
 				INFOPLIST_FILE = SSZipArchive/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
@@ -1213,7 +1387,11 @@
 				INFOPLIST_FILE = SSZipArchive/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
@@ -1236,7 +1414,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SSZipArchive/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = xros;
@@ -1265,7 +1447,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SSZipArchive/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ziparchive.ZipArchive;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = xros;
@@ -1292,6 +1478,15 @@
 			buildConfigurations = (
 				37952C631F63BB7100DD6677 /* Debug */,
 				37952C641F63BB7100DD6677 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6DF7862C2EE35CDD0043F3A8 /* Build configuration list for PBXNativeTarget "ZipArchiveTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DF7862A2EE35CDD0043F3A8 /* Debug */,
+				6DF7862B2EE35CDD0043F3A8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-Mac.xcscheme
+++ b/ZipArchive.xcodeproj/xcshareddata/xcschemes/ZipArchive-Mac.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:ZipArchive.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6DF786222EE35CDD0043F3A8"
+               BuildableName = "ZipArchiveTests.xctest"
+               BlueprintName = "ZipArchiveTests"
+               ReferencedContainer = "container:ZipArchive.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6DF786222EE35CDD0043F3A8"
+               BuildableName = "ZipArchiveTests.xctest"
+               BlueprintName = "ZipArchiveTests"
+               ReferencedContainer = "container:ZipArchive.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/ZipArchiveTests/PermissionsTests.swift
+++ b/ZipArchiveTests/PermissionsTests.swift
@@ -1,0 +1,158 @@
+//
+//  PermissionsTests.swift
+//  PermissionsTests
+//
+//  Created by Bradly Andalman on 12/5/25.
+//
+
+import Testing
+import ZipArchive
+
+struct PermissionsTests {
+    enum TestError: Error {
+        case couldNotEncodeStringAsData
+        case couldNotWriteDataToArchive
+        case unzipExitedWithError
+        case fileIsNotReadable
+        case fileIsNotExecutable
+    }
+    
+    // See https://github.com/ZipArchive/ZipArchive/issues/761
+    @Test func testWriteDataPermissions() async throws {
+        // Make a temporary directory for our archive
+        let tempdirURL = try makeTemporaryDirectory(basename: "writeDataPermissions")
+        let zipURL = tempdirURL.appendingPathComponent("testWriteDataPermissions.zip")
+
+        // Create the data
+        let dataFilename = "content.txt"
+        let content = "content"
+        guard let data = content.data(using: .utf8) else {
+            throw TestError.couldNotEncodeStringAsData
+        }
+                
+        // Create the archive
+        try createArchiveFromData(url: zipURL, dataFilename: dataFilename, data: data)
+                
+        // Extract the contents of the archive using `unzip`
+        // We'll just unzip to our tempdir
+        try runUnzip(zipURL: zipURL, destURL: tempdirURL)
+        
+        // Make sure that the file we unzipped ("content.txt") is readable
+        let fm = FileManager.default
+        let dataFilenameURL = tempdirURL.appendingPathComponent(dataFilename)
+        guard fm.isReadableFile(atPath: dataFilenameURL.path()) else {
+            throw TestError.fileIsNotReadable
+        }
+        
+        // Remove the temporary directory
+        try FileManager.default.removeItem(at: tempdirURL)
+    }
+    
+    // See https://github.com/ZipArchive/ZipArchive/issues/689
+    @Test func testMaintainExecutablePermissions() async throws {
+        // Make a temporary directory
+        let tempdirURL = try makeTemporaryDirectory(basename: "maintainExecutablePermissions")
+        
+        // Write a simple executable file to this directory
+        let script = "#!/bin/sh\n"
+        let executableFilename = "runme.sh"
+        let executableURL = tempdirURL.appendingPathComponent(executableFilename)
+        try script.write(to: executableURL, atomically: true, encoding: .utf8)
+
+        // Make the file executable
+        var attributes = [FileAttributeKey: Any]()
+        attributes[.posixPermissions] = 0o755
+        try FileManager.default.setAttributes(attributes, ofItemAtPath: executableURL.path())
+        
+        // Zip the file
+        let zipURL = tempdirURL.appendingPathComponent("maintainExecutablePermissions.zip")
+        try createArchiveFromFile(fileURL: executableURL, zipURL: zipURL)
+        
+        // Extract the contents of the archive using `unzip`
+        let unzippedURL = tempdirURL.appendingPathComponent("unzipped")
+        try runUnzip(zipURL: zipURL, destURL: unzippedURL)
+        
+        // Make sure that the file we unzipped is executable
+        let fm = FileManager.default
+        let unzippedFileURL = unzippedURL.appendingPathComponent(executableFilename)
+        guard fm.isExecutableFile(atPath: unzippedFileURL.path()) else {
+            throw TestError.fileIsNotExecutable
+        }
+                        
+        // Remove the temporary directory
+        try FileManager.default.removeItem(at: tempdirURL)
+    }
+    
+    func runUnzip(zipURL: URL, destURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = [
+            "-o",
+            zipURL.path,
+            "-d", destURL.path()
+        ]
+        
+        // Run `unzip`
+        try process.run()
+        process.waitUntilExit()
+        
+        // Check exit status
+        guard process.terminationStatus == 0 else {
+            throw TestError.unzipExitedWithError
+        }
+    }
+    
+    func createArchiveFromData(url: URL, dataFilename: String, data: Data) throws {
+        // Create the zip archive
+        let archive = SSZipArchive(path: url.path())
+        
+        // Open the archive
+        archive.open()
+        
+        // Write the data
+        guard archive.write(data, filename: "content.txt", compressionLevel: 0,
+                            password: nil, aes: false) else {
+            throw TestError.couldNotWriteDataToArchive
+        }
+        
+        // Close the archive
+        archive.close()
+    }
+    
+    func createArchiveFromFile(fileURL: URL, zipURL: URL) throws {
+        // Create the zip archive
+        let archive = SSZipArchive(path: zipURL.path())
+        
+        // Open the archive
+        archive.open()
+        
+        // Write the file
+        guard archive.writeFile(fileURL.path(), withPassword: nil) else {
+            throw TestError.couldNotWriteDataToArchive
+        }
+        
+        // Close the archive
+        archive.close()
+    }
+    
+    func makeTemporaryDirectory(basename: String) throws -> URL {
+        let fm = FileManager.default
+        let tempRoot = fm.temporaryDirectory
+        var candidate = tempRoot.appendingPathComponent(basename, isDirectory: true)
+
+        var counter = 0
+        while fm.fileExists(atPath: candidate.path) {
+            counter += 1
+            candidate = tempRoot.appendingPathComponent("\(basename)-\(counter)",
+                                                        isDirectory: true)
+        }
+
+        try fm.createDirectory(
+            at: candidate,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        return candidate
+    }
+}


### PR DESCRIPTION
The switch from host Darwin to Unix (https://github.com/ZipArchive/ZipArchive/issues/689) causes the command line unzip utilty to create unreadable files when it encounters a file with an `external_fa` of 0.

Now, writeData sets `external_fa` explicitly to a reasonable default (based on unzip’s policy).

This commit also includes two tests!

https://github.com/ZipArchive/ZipArchive/issues/761