### PR TITLE
Added dynamic library support in SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     ],
     products: [
         .library(name: "ZipArchive", targets: ["ZipArchive"]),
+        .library(name: "ZipArchive-Dynamic", type: .dynamic, targets: ["ZipArchive"]),
     ],
     targets: [
         .target(


### PR DESCRIPTION
### Extend ZipArchive to support dynamic linking via SPM
CocoaPods is going to end of life this year so many individuals and companies will fully switch to SPM dependency management. Many of my projects use ZipArchive and I need to add it as dynamic library. I added in the Package.swift extra product configuration that will enable XCode to compile ZipArchive as dynamic library (when product does not define it's type explicitly, it is compiled as static lib). As current product configuration stays, users will be able to choose whether they want to add it as static or dynamic library.
Please review it and merge. Thank you for your great job!